### PR TITLE
Fix a couple broken Vagrant provisioning steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ setup: pipenv venv
 
 .PHONY: pipenv
 pipenv:
-	pip install --user pipenv
+	pip3 install --user pipenv
 	@echo Please add $(PIP_HOME) to your PATH variable.
 
 .PHONY: venv

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ setup: pipenv venv
 
 .PHONY: pipenv
 pipenv:
-	pip3 install --user pipenv
+	pip3 install --user pipenv || pip install --user pipenv
 	@echo Please add $(PIP_HOME) to your PATH variable.
 
 .PHONY: venv

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,16 +79,23 @@ Vagrant.configure("2") do |config|
     ln -fs /usr/share/zoneinfo/US/Pacific /etc/localtime
     dpkg-reconfigure -f noninteractive tzdata
 
-    apt-get update
-    apt-get install -y make curl make tmux vim git mariadb-server python3 python3-pip python3-dev libmariadbclient-dev
+    apt-get update && apt-get install -y \
+        curl \
+        git \
+        libmysqlclient-dev \
+        make \
+        mariadb-server \
+        python3 \
+        python3-dev \
+        python3-pip \
+        tmux \
+        vim
 
     # Set up MySQL database and development user
     mysql -e "CREATE DATABASE IF NOT EXISTS hkn;"
     mysql -e "GRANT ALL PRIVILEGES ON hkn.* TO 'hkn'@'localhost' IDENTIFIED BY 'hknweb-dev';"
 
     # Setup pipenv and virtualenv
-    cd /vagrant
-    pip3 install pipenv
-    make venv
+    su - vagrant -c 'cd /vagrant; make setup'
   SHELL
 end

--- a/db.cnf
+++ b/db.cnf
@@ -1,5 +1,5 @@
 [client]
 database = hkn
-user =
-password =
+user = hkn
+password = hknweb-dev
 default-character-set = utf8


### PR DESCRIPTION
`libmariadbclient-dev` isn't in Ubuntu 16.04, so I switched it out for [`libmysqlclient-dev`](https://packages.ubuntu.com/xenial/libmysqlclient-dev), which should work the same essentially. `pip` also isn't available, so I switched it out with `pip3`, and setup needs to be done as the vagrant user to install `pipenv` and the virtualenv to the correct user.

The only change I'm concerned with here is the `pip` -> `pip3` one. Maybe instead the provisioning step can run `pip3 install --user pipenv` and then run `make venv` or something if switching to `pip3` breaks things on windows for example?