### PR TITLE
Add Developer's Certificate of Origin (DCO)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Several major projects and companies (Linux, Gitlab, Chef, in particular) have adopted a
contribution agreement named the developer certificate of origin (“DCO”), which is clearer
and less complex legally than Contributor License Agreements.

I think this is a prudent move for compserv's projects, especially given that we will
have large numbers of contributors (candidates, officers) who will rotate out due
to inactivity, graduation, or the otherwise temporary commitment of officership. This
will make it clear to everyone that we intend to redistribute the work of contributors,
or potentially relicense this work (if consistent with the current license). Hopefully this
will also avoid any future issues of a contributor attempting to revoke their work.

In particular, open-sourcing hkn-rails may bump into these issues, because of the lack of
explicit contribution agreement - we will most likely have to ask for written permission
from each contributor.

Workflow-wise, this will require committers sign-off on major commits (everything that isn't an
obvious fix, i.e. pull requests), but git makes this easy with the `-s` flag (not the `-S` GPG signing
flag): `git commit -s -m "..."`

The major downside of this will most likely be having to request agreement from past committers, and having future committers use the `-s` flag, but because of our cordial relations I think agreeing on signoffs on pull requests only (and not necessarily every individual commit) will be feasible.

The original text can be found at https://developercertificate.org/.
Gitlab's analysis:
https://docs.google.com/document/d/1zpjDzL7yhGBZz3_7jCjWLfRQ1Jryg1mlIVmG8y6B1_Q.
Chef's analysis:
https://blog.chef.io/2016/09/19/introducing-developer-certificate-of-origin/