### PR TITLE
Datetime cleanup (home / event detail)

### DIFF
--- a/hknweb/events/templates/events/show_details.html
+++ b/hknweb/events/templates/events/show_details.html
@@ -30,32 +30,12 @@
       <input type="submit" value="RSVP" />
     </form>
   {% endif %}
-  
+
   <p>{{ event.description }}</p>
-
   <p><b>Event Type</b>: {{ event.event_type }}</p>
-
   <p><b>Location</b>: {{ event.location }}</p>
-  
-  <div id="date-and-time"></div>
-  <!-- Script to render dates prettily -->
-  <script>
-    var start = new Date('{{ event.start_time|date:"c" }}');
-    var end = new Date('{{ event.end_time|date:"c" }}');
-    var sameDayEvent = start.getDate() === end.getDate() && start.getMonth() === end.getMonth() && start.getYear() === end.getYear();
-    
-    if (sameDayEvent) {
-      var HTMLtext = '<p><b>Date</b>: ' + start.toLocaleDateString() + 
-                     '</p> <p><b>Time</b>: ' + start.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'}) + ' to ' + 
-                     end.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
-    } else { // Event starts and ends on different days
-      var HTMLtext = '<p><b>Starts</b>: ' + start.toLocaleDateString() + ' at ' + 
-                     start.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'}) + '</p> <p><b>Ends</b>: ' + 
-                     end.toLocaleDateString() + ' at ' + end.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
-    }
-    document.getElementById("date-and-time").innerHTML = HTMLtext;
-  </script>
-
+  <p><b>Date</b>: {{event.start_time|date:"SHORT_DATE_FORMAT"}}</p>
+  <p><b>Time</b>: {{event.start_time|time}} to {{event.end_time|time}}</p>
   <p><a href="{% url 'events:index' %}">
       Go Back to Calendar
   </a></p>

--- a/hknweb/events/templates/events/show_details.html
+++ b/hknweb/events/templates/events/show_details.html
@@ -34,7 +34,7 @@
   <p>{{ event.description }}</p>
   <p><b>Event Type</b>: {{ event.event_type }}</p>
   <p><b>Location</b>: {{ event.location }}</p>
-  <p><b>Date</b>: {{event.start_time|date:"SHORT_DATE_FORMAT"}}</p>
+  <p><b>Date</b>: {{event.start_time|date:"D, N j, Y"}}</p>
   <p><b>Time</b>: {{event.start_time|time}} to {{event.end_time|time}}</p>
   <p><a href="{% url 'events:index' %}">
       Go Back to Calendar

--- a/hknweb/templates/landing/home.html
+++ b/hknweb/templates/landing/home.html
@@ -118,9 +118,9 @@
             </div>
             <ul>
                 {% for event in events %}
-                    <li>{{ event.name }}
-                    <div id="date-and-time"></div>
-                        <span class="events-card-time">{{ event.start}} - {{ event.end}}</span> 
+                    <li>
+                        {{ event.name }}
+                        <span class="events-card-time">{{event.start_time|date:"D m/d h:i A"}} - {{ event.end_time|date:"h:i A"}}</span>
                     </li>
                 {% endfor %}
             </ul>

--- a/hknweb/views/landing.py
+++ b/hknweb/views/landing.py
@@ -1,56 +1,17 @@
 from django.shortcuts import render
-from hknweb.events.models import Event
-from hknweb.tutoring.models import Tutor
 from django.utils import timezone
-import datetime
-import pytz
+
+from hknweb.events.models import Event
+# from hknweb.tutoring.models import Tutor
 
 
 def home(request):
-    today = timezone.now()
-    # today = datetime.datetime.now()
-    # next_weekday = today
     # TODO: determine earliest weekday for which tutoring still has yet to complete, and query those tutors
-    # tutors = 
-    
-    weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
-    def two_digits(minutes):
-        if minutes < 10:
-            return '0' + str(minutes)
-        return str(minutes)
-    def parse_date(event):
-        timezone.activate(pytz.timezone('America/Los_Angeles'))
-        tz = pytz.timezone('America/Los_Angeles')
-        start = tz.normalize(event.start_time.astimezone(tz))
-        end = tz.normalize(event.end_time.astimezone(tz))
-        start_timetuple, end_timetuple = start.timetuple(), end.timetuple()
-        start_day = weekdays[start_timetuple[6]] + '  ' + str(start_timetuple[1]) + '/' + str(start_timetuple[2])
-        end_day = weekdays[end_timetuple[6]] + '  ' + str(end_timetuple[1]) + '/' + str(end_timetuple[2])
-        start_time = start_day + '  ' + format_time(start_timetuple[3], start_timetuple[4])
-        if (start_day == end_day):
-            end_time = '  ' + format_time(end_timetuple[3], end_timetuple[4])
-        else:
-            end_time = '  ' + end_day + '  ' + format_time(end_timetuple[3], end_timetuple[4])
-        return {'start': start_time, 'end': end_time}
-
-    def format_time(hour, min):
-        if hour == 0:
-            return "12:" + two_digits(min) + " AM  "
-        elif hour > 12:
-            return str(hour - 12) + ":" + two_digits(min) + " PM  "
-        elif hour == 12:
-            return "12:" + two_digits(min) + " PM  "
-        else:
-            return str(hour) + ":" + two_digits(min) + " AM  "
-
-    upcoming_events = Event.objects.filter(start_time__gte=today).order_by('start_time')[:4]
-    events = []
-    for event in upcoming_events:
-        temp_dict = parse_date(event)
-        temp_dict['name'] = event.name
-        events.append(temp_dict)
+    num_events = 4
+    upcoming_events = Event.objects.filter(end_time__gte=timezone.now()) \
+        .order_by('start_time')[:num_events]
     context = {
         # 'tutors': tutors,
-        'events': events,
+        'events': upcoming_events,
     }
     return render(request, 'landing/home.html', context)


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.2/ref/templates/builtins/#date

This pull request simplifies the datetime parsing code by using format strings for the `date` and `time` template filters (linked above):
```html
<p><b>Date</b>: {{event.start_time|date:"D, N j, Y"}}</p>
<p><b>Time</b>: {{event.start_time|time}} to {{event.end_time|time}}</p>
...
<span class="events-card-time">{{event.start_time|date:"D m/d h:i A"}} - {{ event.end_time|date:"h:i A"}}</span>
```

It also changes the events shown on the front page to those *ending* after now(), not just those *starting* after now; viewing in-progress events is useful especially if you're late.