### PR TITLE
Add waitlisting

### DIFF
--- a/hknweb/events/templates/events/show_details.html
+++ b/hknweb/events/templates/events/show_details.html
@@ -74,10 +74,17 @@
         <p class="rsvp-list"> Count: {{ rsvps.count }} </p>
       {% endif %}
       {% for rsvp in rsvps %}
-        <p class="rsvp-list">{{ rsvp.user.first_name }} {{ rsvp.user.last_name }} ({{ rsvp.user }})</p>
+        <p class="rsvp-list">{{ rsvp.user.first_name }} {{ rsvp.user.last_name }} ({{ rsvp.user.email }})</p>
       {% endfor %}
-    {% elif not rsvpd %}
+    {% else %}
       <p class="rsvp-list">No rsvps.</p>
+    {% endif %}
+
+    {% if waitlist %}
+      <h3 class="rsvp-list-title">Waitlist</h3>
+      {% for rsvp in waitlist %}
+        <p class="rsvp-list">{{ rsvp.user.first_name }} {{ rsvp.user.last_name }} ({{ rsvp.user.email }})</p>
+      {% endfor %}
     {% endif %}
   </div>
 </div>

--- a/hknweb/events/templates/events/show_details.html
+++ b/hknweb/events/templates/events/show_details.html
@@ -64,15 +64,14 @@
       <p class="rsvp-list">You have not rsvp'd</p>
     {% endif %}
 
-    
-    <h3 class="rsvp-list-title">RSVPs</h3>
-    
+
+    {% if limit %}
+      <h3 class="rsvp-list-title">RSVPs ({{ rsvps.count }} / {{ limit }})</h3>
+    {% else %}
+      <h3 class="rsvp-list-title">RSVPs</h3>
+    {% endif %}
+
     {% if rsvps %}
-      {% if limit %}
-        <p class="rsvp-list"> Count: {{ rsvps.count }} / {{ limit }} </p>
-      {% else %}
-        <p class="rsvp-list"> Count: {{ rsvps.count }} </p>
-      {% endif %}
       {% for rsvp in rsvps %}
         <p class="rsvp-list">{{ rsvp.user.first_name }} {{ rsvp.user.last_name }} ({{ rsvp.user.email }})</p>
       {% endfor %}
@@ -81,7 +80,11 @@
     {% endif %}
 
     {% if waitlist %}
-      <h3 class="rsvp-list-title">Waitlist</h3>
+      {% if waitlisted %}
+        <h3 class="rsvp-list-title">Waitlist (your position: {{ waitlist_position }})</h3>
+      {% else %}
+        <h3 class="rsvp-list-title">Waitlist</h3>
+      {% endif %}
       {% for rsvp in waitlist %}
         <p class="rsvp-list">{{ rsvp.user.first_name }} {{ rsvp.user.last_name }} ({{ rsvp.user.email }})</p>
       {% endfor %}

--- a/hknweb/events/views.py
+++ b/hknweb/events/views.py
@@ -41,7 +41,8 @@ def show_details(request, id):
 
     event = get_object_or_404(Event, pk=id)
 
-    rsvpd = Rsvp.objects.filter(user=request.user, event=event).exists()
+    rsvp = Rsvp.objects.filter(user=request.user, event=event).first()
+    rsvpd = rsvp is not None
     rsvps = Rsvp.objects.filter(event=event)
     limit = event.rsvp_limit
     rsvps = event.admitted_set()
@@ -53,6 +54,12 @@ def show_details(request, id):
         'limit': limit,
         'waitlist': waitlist,
     }
+    if rsvp is not None:
+        context['waitlisted'] = rsvp.waitlisted()
+        context['waitlist_position'] = rsvp.waitlist_position()
+    else:
+        context['waitlisted'] = False
+        context['waitlist_position'] = None
     return render(request, 'events/show_details.html', context)
 
 @login_required(login_url='/accounts/login/')


### PR DESCRIPTION
This PR adds waitlisting by removing the requirement that rsvp count is under the event's `rsvp_count` cap, and allowing rsvps regardless.

Waitlist position is calculated dynamically, and is not stored anywhere. Waitlist position is 1-indexed (i.e. if nobody is in front of you but you are on the waitlist, you are in waitlist position 1). This is determined by counting the number of people before you (ordered by rsvp creation time), then slicing at the rsvp_count.

I've also removed some redundant authentication checking on the rsvp() view, which should be performed by the `@login_required` annotation anyways. 

Side note, should we post screenshots every time we make visual changes?

![Screenshot from 2019-11-10 22-22-28](https://user-images.githubusercontent.com/2917145/68565517-9f795580-0408-11ea-913b-bd13812362a0.png)