### PR TITLE
Remove livereload from INSTALLED_APPS in dev

### DIFF
--- a/hknweb/settings/dev.py
+++ b/hknweb/settings/dev.py
@@ -10,10 +10,6 @@ import os
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-INSTALLED_APPS += [
-    'livereload',
-]
-
 ALLOWED_HOSTS = ['localhost','127.0.0.1','hkn.eecs.berkeley.edu','hkn.mu','hknweb-geohh.c9users.io']
 
 DATABASES = {


### PR DESCRIPTION
Livereload is specified as a dependency in INSTALLED_APPS in dev.py, which means that only installing the prod dependencies:

```sh
pipenv install
```

will result in the following missing dependency error:
```sh
$ make
HKNWEB_MODE='dev' pipenv run python ./manage.py runserver 127.0.0.1:3000
Unhandled exception in thread started by <function check_errors.<locals>.wrapper at 0x000002E2A51149D8>
Traceback (most recent call last):
  File "C:\Users\jimmy\.virtualenvs\hknweb-Qqb4mH1C\lib\site-packages\django\utils\autoreload.py", line 225, in wrapper
    fn(*args, **kwargs)
  File "C:\Users\jimmy\.virtualenvs\hknweb-Qqb4mH1C\lib\site-packages\django\core\management\commands\runserver.py", line 109, in inner_run
    autoreload.raise_last_exception()
  File "C:\Users\jimmy\.virtualenvs\hknweb-Qqb4mH1C\lib\site-packages\django\utils\autoreload.py", line 248, in raise_last_exception   
    raise _exception[1]
  File "C:\Users\jimmy\.virtualenvs\hknweb-Qqb4mH1C\lib\site-packages\django\core\management\__init__.py", line 337, in execute        
    autoreload.check_errors(django.setup)()
  File "C:\Users\jimmy\.virtualenvs\hknweb-Qqb4mH1C\lib\site-packages\django\utils\autoreload.py", line 225, in wrapper
    fn(*args, **kwargs)
  File "C:\Users\jimmy\.virtualenvs\hknweb-Qqb4mH1C\lib\site-packages\django\__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "C:\Users\jimmy\.virtualenvs\hknweb-Qqb4mH1C\lib\site-packages\django\apps\registry.py", line 89, in populate
    app_config = AppConfig.create(entry)
  File "C:\Users\jimmy\.virtualenvs\hknweb-Qqb4mH1C\lib\site-packages\django\apps\config.py", line 90, in create
    module = import_module(entry)
  File "C:\Users\jimmy\.virtualenvs\hknweb-Qqb4mH1C\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 965, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'livereload'
```

The workaround is to install all (development) dependencies:

```sh
pipenv install --dev
```

But if we want the site to work for new developers out-of-the-box, we should just remove this little-used feature from the dev settings.