### PR TITLE
Add event slug label, help text

### DIFF
--- a/hknweb/events/forms.py
+++ b/hknweb/events/forms.py
@@ -17,7 +17,7 @@ class EventForm(forms.ModelForm):
     # )
     class Meta:
         model = Event
-        fields = ('name', 'slug', 'location', 'description', 'event_type','start_time', 'end_time', 'rsvp_limit')
+        fields = ('name', 'slug', 'location', 'description', 'event_type', 'start_time', 'end_time', 'rsvp_limit')
                   #'markdown', 'event_type', 'view_permission', 'rsvp_type', 'transportation')
 
         #this makes formatting easier, but it shows as MM/DD/YYY HH:MM AM/PM which apparently is not valid for the datetimefield :(
@@ -32,8 +32,10 @@ class EventForm(forms.ModelForm):
         help_texts = {
             'start_time': 'mm/dd/yyyy hh:mm, 24-hour time',
             'end_time': 'mm/dd/yyyy hh:mm, 24-hour time',
+            'slug': 'e.g. <semester>-<name>',
         }
 
         labels = {
+            'slug': 'URL-friendly name',
             'rsvp_limit': 'RSVP limit',
         }


### PR DESCRIPTION
Adds the following label and help text for the _slug_ field in the Event form:

URL-friendly name (e.g. <semester>-<name>)

![Screenshot from 2020-04-01 21-38-38](https://user-images.githubusercontent.com/2917145/78211208-2cc55100-7461-11ea-8915-5d1fc4ec544d.png)