### PR TITLE
Fix makefile duplicate 'createsuperuser'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,7 @@ venv: Pipfile Pipfile.lock
 createsuperuser:
 	HKNWEB_MODE='dev' pipenv run python ./manage.py createsuperuser
 
-.PHONY: superuser
-createsuperuser:
-	HKNWEB_MODE='dev' pipenv run python ./manage.py createsuperuser
+superuser: createsuperuser
 
 .PHONY: migrate
 migrate:


### PR DESCRIPTION
This was intended to be a 'make superuser' task, but I apparently never finished this. I've cleaned this up so it's just an alias for createsuperuser.