### PR TITLE
Events calendar fix

### DIFF
--- a/hknweb/events/templates/events/index.html
+++ b/hknweb/events/templates/events/index.html
@@ -6,14 +6,14 @@
 {% block header %}
 <!-- Scripts which make the calendar work:-->
 <link rel="stylesheet" href="{% static "events/style.css" %}">
-<link rel="stylesheet" href="https://unpkg.com/@fullcalendar/core/main.css" />
-<link rel="stylesheet" href="https://unpkg.com/@fullcalendar/daygrid/main.css" />
-<link rel="stylesheet" href="https://unpkg.com/@fullcalendar/timegrid/main.css" />
+<link rel="stylesheet" href="https://unpkg.com/@fullcalendar/core@4.4.0/main.css" />
+<link rel="stylesheet" href="https://unpkg.com/@fullcalendar/daygrid@4.4.0/main.css" />
+<link rel="stylesheet" href="https://unpkg.com/@fullcalendar/timegrid@4.4.0/main.css" />
 <link rel="stylesheet" href="{% static "css/tachyons.css" %}" />
 
-<script src="https://unpkg.com/@fullcalendar/core/main.js"></script>
-<script src="https://unpkg.com/@fullcalendar/daygrid/main.js"></script>
-<script src="https://unpkg.com/@fullcalendar/timegrid/main.js"></script>
+<script src="https://unpkg.com/@fullcalendar/core@4.4.0/main.js"></script>
+<script src="https://unpkg.com/@fullcalendar/daygrid@4.4.0/main.js"></script>
+<script src="https://unpkg.com/@fullcalendar/timegrid@4.4.0/main.js"></script>
 
 <script type="text/javascript">
     document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
Specifying calendar version to 4.4.0 after fullcalendar.io upgraded to v5. This is a solid temporary solution and a solid semi-temporary solution (at least until fullcalendar deprecates v4). Worst case is that we may need to upgrade to the newest version in a couple of years. 