### PR TITLE
changed calendars aspect ratio to 1.25, can fit 5 events in one cell now

### DIFF
--- a/hknweb/events/templates/events/index.html
+++ b/hknweb/events/templates/events/index.html
@@ -30,7 +30,7 @@
             },
             navLinks: true,
             eventLimit: true,
-            aspectRatio: 1.75,
+            aspectRatio: 1.25,
             views: {
                 dayGrid: {
                     fixedWeekCount: false,


### PR DESCRIPTION
This fixes the problem of events being hidden (assuming we have no more than 5 events in a day). Will also look into event ordering.