### PR TITLE
Candidate COMPSERV-52 COMPSERV-53 COMPSERV-54 COMPSERV-77

### DIFF
--- a/hknweb/candidate/admin.py
+++ b/hknweb/candidate/admin.py
@@ -1,11 +1,10 @@
 from django.contrib import admin
 from django.contrib.auth.models import User
-from django.http import HttpResponse
 
-from .models import OffChallenge, BitByteActivity, Announcement, CandidateForm
-from .views import send_challenge_confirm_email, send_bitbyte_confirm_email
+from hknweb.utils import export_model_as_csv
 
-import csv
+from .models import Announcement, BitByteActivity, CandidateForm, OffChallenge
+from .views import send_bitbyte_confirm_email, send_challenge_confirm_email
 
 
 class OffChallengeAdmin(admin.ModelAdmin):
@@ -153,21 +152,6 @@ class CandidateFormAdmin(admin.ModelAdmin):
         queryset.update(visible=False)
 
     set_invisible.short_description = "Set selected as invisible"
-
-# Helper. @source: http://books.agiliq.com/projects/django-admin-cookbook/en/latest/export.html
-def export_model_as_csv(model, queryset):
-    meta = model.model._meta
-    field_names = [field.name for field in meta.fields]
-
-    response = HttpResponse(content_type='text/csv')
-    response['Content-Disposition'] = 'attachment; filename={}.csv'.format(meta)
-    writer = csv.writer(response)
-
-    writer.writerow(field_names)
-    for obj in queryset:
-        writer.writerow([getattr(obj, field) for field in field_names])
-
-    return response
 
 
 admin.site.register(CandidateForm, CandidateFormAdmin)

--- a/hknweb/candidate/constants.py
+++ b/hknweb/candidate/constants.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+
+
+REQUIREMENT_TITLES_TEMPLATE = "{name} ({num_required} required, {num_remaining} remaining)"
+REQUIREMENT_TITLES_MANDATORY = "Mandatory Meetings (ALL required)"
+
+REQUIREMENT_EVENTS = [
+    settings.MANDATORY_EVENT,
+    settings.FUN_EVENT,
+    settings.BIG_FUN_EVENT,
+    settings.SERV_EVENT,
+    settings.PRODEV_EVENT,
+]
+
+class ATTR:
+    TITLE = "title"
+    STATUS = "status"
+    COLOR = "color"
+    CONFIRMED = "confirmed"
+    UNCONFIRMED = "unconfirmed"
+    NUM_PENDING = "num_pending"
+    NUM_REJECTED = "num_rejected"
+    NUM_CONFIRMED = "num_confirmed"
+    NUM_BITBYTES = "num_bitbytes"

--- a/hknweb/candidate/forms.py
+++ b/hknweb/candidate/forms.py
@@ -1,8 +1,10 @@
 from django import forms
-from .models import OffChallenge, BitByteActivity
 from django.contrib.auth.models import User
 
 from dal import autocomplete
+
+from .models import BitByteActivity, OffChallenge
+
 
 class ChallengeRequestForm(forms.ModelForm):
 

--- a/hknweb/candidate/models.py
+++ b/hknweb/candidate/models.py
@@ -1,6 +1,6 @@
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.conf import settings
 
 MAX_STRLEN = 150 # default max length for char fields
 MAX_TXTLEN = 2000 # default max length for text fields

--- a/hknweb/candidate/static/candidate/style.css
+++ b/hknweb/candidate/static/candidate/style.css
@@ -29,6 +29,13 @@
     background-size: 1.25em 1.25em;
 }
 
+.req-title {
+    color: white;
+    border-radius: 1em;
+    padding-left: 0.4em;
+    padding-right: 0.4em;
+}
+
 .done {
     background-image: url('yes.png');
 }

--- a/hknweb/candidate/templates/candidate/index.html
+++ b/hknweb/candidate/templates/candidate/index.html
@@ -138,7 +138,7 @@ Candidate Portal
 
             <h4>Miscellaneous Requirements</h4>
             <ul class="events-list" type="1">
-                <li>Administer 1-2 Course Surveys</li>
+                <!-- <li>Administer 1-2 Course Surveys</li> -->
                 <li>Complete a Committee Project</li>
                 <li>Pay all dues (2 sets)</li>
                 <li>Complete all required forms</li>

--- a/hknweb/candidate/templates/candidate/index.html
+++ b/hknweb/candidate/templates/candidate/index.html
@@ -67,7 +67,9 @@ Candidate Portal
                         {% else %}
                             <span class="req not-done"></span>
                         {% endif %}
-                        Mandatory Meetings (ALL required)
+                        <span style="background:{{ req_colors.mandatory }}" class="req-title">
+                            Mandatory Meetings (ALL required)
+                        </span>
                     </li>
                     <ul class="conf-events">
                         {% for event in confirmed_events.mandatory %}
@@ -86,7 +88,9 @@ Candidate Portal
                         {% else %}
                             <span class="req not-done"></span>
                         {% endif %}
+                        <span style="background:{{ req_colors.fun }}" class="req-title">
                         Fun ({{ req_required.fun }} required, {{ req_remaining.fun }} remaining)
+                        </span>
                     <ul class="conf-events">
                         {% for event in confirmed_events.fun %}
                             <li>{{ event.name }}<br/></li>
@@ -104,7 +108,9 @@ Candidate Portal
                         {% else %}
                             <span class="req not-done"></span>
                         {% endif %}
+                        <span style="background:{{ req_colors.big_fun }}" class="req-title">
                         Big Fun ({{ req_required.big_fun }} required, {{ req_remaining.big_fun }} remaining)
+                        </span>
                     </li>
                     <ul class="conf-events">
                         {% for event in confirmed_events.big_fun %}
@@ -123,7 +129,9 @@ Candidate Portal
                         {% else %}
                             <span class="req not-done"></span>
                         {% endif %}
+                        <span style="background:{{ req_colors.serv }}" class="req-title">
                         Service ({{ req_required.serv }} required, {{ req_remaining.serv }} remaining)
+                        </span>
                     </li>
                     <ul class="conf-events">
                         {% for event in confirmed_events.serv %}
@@ -142,7 +150,9 @@ Candidate Portal
                         {% else %}
                             <span class="req not-done"></span>
                         {% endif %}
+                        <span style="background:{{ req_colors.prodev }}" class="req-title">
                         Prodev ({{ req_required.prodev }} required, {{ req_remaining.prodev }} remaining)
+                        </span>
                     </li>
                     <ul class="conf-events">
                         {% for event in confirmed_events.prodev %}
@@ -219,7 +229,7 @@ Candidate Portal
                     <ul class="events-sublist">
 
                         {% if not candidate_forms %}
-                            No candiate forms at this time.
+                            No candidate forms at this time.
                         {% endif %}
 
                         {% for form in candidate_forms %}

--- a/hknweb/candidate/templates/candidate/index.html
+++ b/hknweb/candidate/templates/candidate/index.html
@@ -13,233 +13,148 @@ Candidate Portal
 
 {% block content %}
 <div class="parent centered">
+    <section>
+        <h2>Announcements</h2>
 
-    <div class="right-column">
-        <section>
-            <h2>Announcements</h2>
+        {% if not announcements %}
+            No announcements at this time.
+        {% endif %}
 
-            {% if not announcements %}
-                No announcements at this time.
-            {% endif %}
+        {% for announcement in announcements %}
+            <p>
+            <strong>{{ announcement.title }}</strong> [{{ announcement.release_date|date:"m/d/Y" }}]<br>
+            {{ announcement.text }}
+            </p>
+        {% endfor %}
+    </section>
+    <br>
+    <section>
+        <h2>Upcoming Events</h2>
+        {% if upcoming_events %}
+        <table class="full-table">
+            <thead>
+                <th align="left">Event</th>
+                <th align="left">Time</th>
+                <th align="left">Location</th>
+            </thead>
 
-            {% for announcement in announcements %}
-                <p>
-                <strong>{{ announcement.title }}</strong> [{{ announcement.release_date|date:"m/d/Y" }}]<br>
-                {{ announcement.text }}
-                </p>
+            <tbody>
+            {% for event in upcoming_events %}
+                <tr>
+                    <td><a href="{% url 'events:detail' event.id %}"> {{ event.name }} </a></td>
+                    <td>{{event.start_time|date:"D m/d h:i A"}} - {{ event.end_time|date:"h:i A"}}</td>
+                    <td>{{ event.location }}</td>
+                </tr>
             {% endfor %}
-        </section>
-        <br>
-        <section>
-            <h2>Upcoming Events</h2>
-            {% if upcoming_events %}
-            <table class="full-table">
-                <thead>
-                    <th align="left">Event</th>
-                    <th align="left">Time</th>
-                    <th align="left">Location</th>
-                </thead>
+            </tbody>
+        </table>
+        {% endif %}
+    </section>
+    <br>
+    <section id="candidate-checklist">
+        <h2 class="events-list">Checklist</h2>
 
-                <tbody>
-                {% for event in upcoming_events %}
-                    <tr>
-                        <td><a href="{% url 'events:detail' event.id %}"> {{ event.name }} </a></td>
-                        <td>{{event.start_time|date:"D m/d h:i A"}} - {{ event.end_time|date:"h:i A"}}</td>
-                        <td>{{ event.location }}</td>
-                    </tr>
+        <div class="checklist-left-col">
+            <h4>Events</h4>
+            <ul class="checkboxes events-list">
+                {% for event in events %}
+                    <li>
+                        {% if event.status %}
+                            <span class="req done"></span>
+                        {% else %}
+                            <span class="req not-done"></span>
+                        {% endif %}
+                        <span style="background:{{ event.color }}" class="req-title">
+                            {{ event.title }}
+                        </span>
+                    </li>
+                    <ul class="conf-events">
+                        {% for confirmed in event.confirmed %}
+                            <li>{{ confirmed.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <ul class="unconf-events">
+                        {% for unconfirmed in event.unconfirmed %}
+                            <li>{{ unconfirmed.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <br/>
                 {% endfor %}
-                </tbody>
-            </table>
-            {% endif %}
-        </section>
-    </div>
-    <div class="left-column">
-        <br id="break">
-        <section id="candidate-checklist">
-            <h2 class="events-list">Checklist</h2>
-
-            <div class="checklist-left-col">
-                <h4>Events</h4>
-                <ul class="checkboxes events-list">
-                    <li>
-                        {% if req_statuses.mandatory %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        <span style="background:{{ req_colors.mandatory }}" class="req-title">
-                            Mandatory Meetings (ALL required)
-                        </span>
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.mandatory %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.mandatory %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <br/>
-                    <li>
-                        {% if req_statuses.fun %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        <span style="background:{{ req_colors.fun }}" class="req-title">
-                        Fun ({{ req_required.fun }} required, {{ req_remaining.fun }} remaining)
-                        </span>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.fun %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.fun %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <br/>
-                    <li>
-                        {% if req_statuses.big_fun %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        <span style="background:{{ req_colors.big_fun }}" class="req-title">
-                        Big Fun ({{ req_required.big_fun }} required, {{ req_remaining.big_fun }} remaining)
-                        </span>
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.big_fun %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.big_fun %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <br/>
-                    <li>
-                        {% if req_statuses.serv %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        <span style="background:{{ req_colors.serv }}" class="req-title">
-                        Service ({{ req_required.serv }} required, {{ req_remaining.serv }} remaining)
-                        </span>
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.serv %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.serv %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <br/>
-                    <li>
-                        {% if req_statuses.prodev %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        <span style="background:{{ req_colors.prodev }}" class="req-title">
-                        Prodev ({{ req_required.prodev }} required, {{ req_remaining.prodev }} remaining)
-                        </span>
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.prodev %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.prodev %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
+            </ul>
+        </div>
+        <div class="checklist-right-col">
+            <h4>{{ interactivities.title }}</h4>
+            <ul class="checkboxes">
+                <li>
+                    <!-- challenges and hangouts have the same done status-->
+                    {% if interactivities.status %}
+                        <span class="req done"></span>
+                    {% else %}
+                        <span class="req not-done"></span>
+                    {% endif %}
+                    {{ interactivities.officer_challenge.title }}
+                </li>
+                <a href="{% url 'candidate:candrequests' %}">
+                    (View/Request Officer Challenge Confirmations)</a>
+                <ul>
+                    <li>{{ interactivities.officer_challenge.num_pending }} pending</li>
+                    <li>{{ interactivities.officer_challenge.num_rejected }} rejected</li>
+                    <li>{{ interactivities.officer_challenge.num_confirmed }} confirmed</li>
                 </ul>
-            </div>
-            <div class="checklist-right-col">
-                <h4>Interactivities ({{ req_required.hangout.either }} total required, {{ req_remaining.hangout.either }} remaining)</h4>
-                <ul class="checkboxes">
-                    <li>
-                        <!-- challenges and hangouts have the same done status-->
-                        {% if req_statuses.hangout %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        Officer Challenges ({{ req_required.hangout.challenge }} required, {{ req_remaining.hangout.challenge }} remaining)
-                    </li>
-                    <a href="{% url 'candidate:candrequests' %}">
-                        (View/Request Officer Challenge Confirmations)</a>
-                    <ul>
-                        <li>{{ num_pending }} pending</li>
-                        <li>{{ num_rejected }} rejected</li>
-                        <li>{{ num_confirmed }} confirmed</li>
-                    </ul>
-                    <li>
-                        {% if req_statuses.hangout %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        Officer Hangouts ({{ req_required.hangout.hangout }} required, {{ req_remaining.hangout.hangout }} remaining)
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.hangout %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.hangout %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
+                <li>
+                    {% if interactivities.status %}
+                        <span class="req done"></span>
+                    {% else %}
+                        <span class="req not-done"></span>
+                    {% endif %}
+                    {{ interactivities.officer_hangout.title }}
+                </li>
+                <ul class="conf-events">
+                    {% for event in confirmed_events.hangout %}
+                        <li>{{ event.name }}<br/></li>
+                    {% endfor %}
                 </ul>
-
-                <h4>Bit-Byte ({{ req_required.bitbyte }} required, {{ req_remaining.bitbyte }} remaining)</h4>
-                <ul class="checkboxes">
-                    <li>
-                        <!-- do not distinguish between boba and adventures-->
-                        {% if req_statuses.bitbyte %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        {{ num_bitbytes }} Bit-Byte Activities Completed
-                    </li>
-                    <a href="{% url 'candidate:bitbyte' %}">
-                        (View/Request Bit-Byte Confirmations)</a>
+                <ul class="unconf-events">
+                    {% for event in unconfirmed_events.hangout %}
+                        <li>{{ event.name }}<br/></li>
+                    {% endfor %}
                 </ul>
+            </ul>
 
-                <h4>Miscellaneous Requirements</h4>
-                <ul class="events-list" type="1">
-                    <li>Administer 1-2 Course Surveys</li>
-                    <li>Complete a Committee Project</li>
-                    <li>Pay all dues (2 sets)</li>
-                    <li>Complete all required forms</li>
-                    <ul class="events-sublist">
+            <h4>{{ bitbyte.title }}</h4>
+            <ul class="checkboxes">
+                <li>
+                    <!-- do not distinguish between boba and adventures-->
+                    {% if bitbyte.status %}
+                        <span class="req done"></span>
+                    {% else %}
+                        <span class="req not-done"></span>
+                    {% endif %}
+                    {{ bitbyte.num_bitbytes }} Bit-Byte Activities Completed
+                </li>
+                <a href="{% url 'candidate:bitbyte' %}">
+                    (View/Request Bit-Byte Confirmations)</a>
+            </ul>
 
-                        {% if not candidate_forms %}
-                            No candidate forms at this time.
-                        {% endif %}
+            <h4>Miscellaneous Requirements</h4>
+            <ul class="events-list" type="1">
+                <li>Administer 1-2 Course Surveys</li>
+                <li>Complete a Committee Project</li>
+                <li>Pay all dues (2 sets)</li>
+                <li>Complete all required forms</li>
+                <ul class="events-sublist">
 
-                        {% for form in candidate_forms %}
-                            <li><a href={{ form.link }}>{{ form.name }}</a> (due {{ form.duedate }})</li>
-                        {% endfor %}
+                    {% if not candidate_forms %}
+                        No candidate forms at this time.
+                    {% endif %}
 
-                    </ul>
+                    {% for form in candidate_forms %}
+                        <li><a href={{ form.link }}>{{ form.name }}</a> (due {{ form.duedate }})</li>
+                    {% endfor %}
+
                 </ul>
-            </div>
-        </section>
-    </div>
+            </ul>
+        </div>
+    </section>
 </div>
 {% endblock %}

--- a/hknweb/candidate/templates/candidate/index.html
+++ b/hknweb/candidate/templates/candidate/index.html
@@ -31,203 +31,6 @@ Candidate Portal
         </section>
         <br>
         <section>
-            <h2>Candidate Requirements</h2>
-            <ol class="events-list" type="1">
-                <li>Attend Candidate Meeting</li>
-                <li>Attend all 3 General Meetings</li>
-                <li>Attend 3+ Fun Events</li>
-                <li>Attend 1+ Big Fun Events</li>
-                <li>Attend 1+ Serv Events</li>
-                <li>Complete 3+ Interactivities</li>
-                <ul class="events-sublist">
-                    <li>Officer Challenges</li>
-                    <li>Officer Hangouts</li>
-                </ul>
-                <li>Attend 1+ Prodev Event</li>
-                <li>Administer 1-2 Course Surveys</li>
-                <li>Complete a Committee Project</li>
-                <li>Complete Bit-Byte Requirements</li>
-                <ul class="events-sublist">
-                    <li>2 Adventures</li>
-                    <li>1 Boba or Equivalent</li>
-                </ul>
-                <li>Pay all dues (2 sets)</li>
-                <li>Complete all required forms</li>
-                <ul class="events-sublist">
-
-                    {% if not candidate_forms %}
-                        No candiate forms at this time.
-                    {% endif %}
-
-                    {% for form in candidate_forms %}
-                        <li><a href={{ form.link }}>{{ form.name }}</a> (due {{ form.duedate }})</li>
-                    {% endfor %}
-
-                </ul>
-            </ol>
-        </section>
-    </div>
-    <div class="left-column">
-        <br id="break">
-        <section id="candidate-checklist">
-            <h2 class="events-list">Checklist</h2>
-
-            <div class="checklist-left-col">
-                <h4>Events</h4>
-                <ul class="checkboxes events-list">
-                    <li>
-                        {% if req_statuses.mandatory_meetings %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        Mandatory Meetings
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.mandatory_meetings %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.mandatory_meetings %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <br/>
-                    <li>
-                        {% if req_statuses.fun %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        Fun
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.fun %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.fun %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <br/>
-                    <li>
-                        {% if req_statuses.big_fun %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        Big Fun
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.big_fun %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.big_fun %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <br/>
-                    <li>
-                        {% if req_statuses.serv %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        Service
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.serv %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.serv %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <br/>
-                    <li>
-                        {% if req_statuses.prodev %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        Prodev
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.prodev %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.prodev %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                </ul>
-            </div>
-            <div class="checklist-right-col">
-                <h4>Interactivities</h4>
-                <ul class="checkboxes">
-                    <li>
-                        <!-- challenges and hangouts have the same done status-->
-                        {% if req_statuses.hangout %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        Officer Challenges
-                    </li>
-                    <a href="{% url 'candidate:candrequests' %}">
-                        (View/Request Officer Challenge Confirmations)</a>
-                    <ul>
-                        <li>{{ num_pending }} pending</li>
-                        <li>{{ num_rejected }} rejected</li>
-                        <li>{{ num_confirmed }} confirmed</li>
-                    </ul>
-                    <li>
-                        {% if req_statuses.hangout %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        Officer Hangouts
-                    </li>
-                    <ul class="conf-events">
-                        {% for event in confirmed_events.hangout %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                    <ul class="unconf-events">
-                        {% for event in unconfirmed_events.hangout %}
-                            <li>{{ event.name }}<br/></li>
-                        {% endfor %}
-                    </ul>
-                </ul>
-
-                <h4>Bit-Byte</h4>
-                <ul class="checkboxes">
-                    <li>
-                        <!-- do not distinguish between boba and adventures-->
-                        {% if req_statuses.bitbyte %}
-                            <span class="req done"></span>
-                        {% else %}
-                            <span class="req not-done"></span>
-                        {% endif %}
-                        {{ num_bitbytes }} Bit-Byte Activities Completed
-                    </li>
-                    <a href="{% url 'candidate:bitbyte' %}">
-                        (View/Request Bit-Byte Confirmations)</a>
-                </ul>
-            </div>
-        </section>
-        <br>
-        <section>
             <h2>Upcoming Events</h2>
             {% if upcoming_events %}
             <table class="full-table">
@@ -248,6 +51,184 @@ Candidate Portal
                 </tbody>
             </table>
             {% endif %}
+        </section>
+    </div>
+    <div class="left-column">
+        <br id="break">
+        <section id="candidate-checklist">
+            <h2 class="events-list">Checklist</h2>
+
+            <div class="checklist-left-col">
+                <h4>Events</h4>
+                <ul class="checkboxes events-list">
+                    <li>
+                        {% if req_statuses.mandatory %}
+                            <span class="req done"></span>
+                        {% else %}
+                            <span class="req not-done"></span>
+                        {% endif %}
+                        Mandatory Meetings (ALL required)
+                    </li>
+                    <ul class="conf-events">
+                        {% for event in confirmed_events.mandatory %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <ul class="unconf-events">
+                        {% for event in unconfirmed_events.mandatory %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <br/>
+                    <li>
+                        {% if req_statuses.fun %}
+                            <span class="req done"></span>
+                        {% else %}
+                            <span class="req not-done"></span>
+                        {% endif %}
+                        Fun ({{ req_required.fun }} required, {{ req_remaining.fun }} remaining)
+                    <ul class="conf-events">
+                        {% for event in confirmed_events.fun %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <ul class="unconf-events">
+                        {% for event in unconfirmed_events.fun %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <br/>
+                    <li>
+                        {% if req_statuses.big_fun %}
+                            <span class="req done"></span>
+                        {% else %}
+                            <span class="req not-done"></span>
+                        {% endif %}
+                        Big Fun ({{ req_required.big_fun }} required, {{ req_remaining.big_fun }} remaining)
+                    </li>
+                    <ul class="conf-events">
+                        {% for event in confirmed_events.big_fun %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <ul class="unconf-events">
+                        {% for event in unconfirmed_events.big_fun %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <br/>
+                    <li>
+                        {% if req_statuses.serv %}
+                            <span class="req done"></span>
+                        {% else %}
+                            <span class="req not-done"></span>
+                        {% endif %}
+                        Service ({{ req_required.serv }} required, {{ req_remaining.serv }} remaining)
+                    </li>
+                    <ul class="conf-events">
+                        {% for event in confirmed_events.serv %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <ul class="unconf-events">
+                        {% for event in unconfirmed_events.serv %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <br/>
+                    <li>
+                        {% if req_statuses.prodev %}
+                            <span class="req done"></span>
+                        {% else %}
+                            <span class="req not-done"></span>
+                        {% endif %}
+                        Prodev ({{ req_required.prodev }} required, {{ req_remaining.prodev }} remaining)
+                    </li>
+                    <ul class="conf-events">
+                        {% for event in confirmed_events.prodev %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <ul class="unconf-events">
+                        {% for event in unconfirmed_events.prodev %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                </ul>
+            </div>
+            <div class="checklist-right-col">
+                <h4>Interactivities ({{ req_required.hangout.either }} total required, {{ req_remaining.hangout.either }} remaining)</h4>
+                <ul class="checkboxes">
+                    <li>
+                        <!-- challenges and hangouts have the same done status-->
+                        {% if req_statuses.hangout %}
+                            <span class="req done"></span>
+                        {% else %}
+                            <span class="req not-done"></span>
+                        {% endif %}
+                        Officer Challenges ({{ req_required.hangout.challenge }} required, {{ req_remaining.hangout.challenge }} remaining)
+                    </li>
+                    <a href="{% url 'candidate:candrequests' %}">
+                        (View/Request Officer Challenge Confirmations)</a>
+                    <ul>
+                        <li>{{ num_pending }} pending</li>
+                        <li>{{ num_rejected }} rejected</li>
+                        <li>{{ num_confirmed }} confirmed</li>
+                    </ul>
+                    <li>
+                        {% if req_statuses.hangout %}
+                            <span class="req done"></span>
+                        {% else %}
+                            <span class="req not-done"></span>
+                        {% endif %}
+                        Officer Hangouts ({{ req_required.hangout.hangout }} required, {{ req_remaining.hangout.hangout }} remaining)
+                    </li>
+                    <ul class="conf-events">
+                        {% for event in confirmed_events.hangout %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                    <ul class="unconf-events">
+                        {% for event in unconfirmed_events.hangout %}
+                            <li>{{ event.name }}<br/></li>
+                        {% endfor %}
+                    </ul>
+                </ul>
+
+                <h4>Bit-Byte ({{ req_required.bitbyte }} required, {{ req_remaining.bitbyte }} remaining)</h4>
+                <ul class="checkboxes">
+                    <li>
+                        <!-- do not distinguish between boba and adventures-->
+                        {% if req_statuses.bitbyte %}
+                            <span class="req done"></span>
+                        {% else %}
+                            <span class="req not-done"></span>
+                        {% endif %}
+                        {{ num_bitbytes }} Bit-Byte Activities Completed
+                    </li>
+                    <a href="{% url 'candidate:bitbyte' %}">
+                        (View/Request Bit-Byte Confirmations)</a>
+                </ul>
+
+                <h4>Miscellaneous Requirements</h4>
+                <ul class="events-list" type="1">
+                    <li>Administer 1-2 Course Surveys</li>
+                    <li>Complete a Committee Project</li>
+                    <li>Pay all dues (2 sets)</li>
+                    <li>Complete all required forms</li>
+                    <ul class="events-sublist">
+
+                        {% if not candidate_forms %}
+                            No candiate forms at this time.
+                        {% endif %}
+
+                        {% for form in candidate_forms %}
+                            <li><a href={{ form.link }}>{{ form.name }}</a> (due {{ form.duedate }})</li>
+                        {% endfor %}
+
+                    </ul>
+                </ul>
+            </div>
         </section>
     </div>
 </div>

--- a/hknweb/candidate/templates/candidate/offreq.html
+++ b/hknweb/candidate/templates/candidate/offreq.html
@@ -25,6 +25,7 @@ Officer Challenges from You
                     <th>Requester</th>
                     <th>Overall Status</th>
                     <th>Your Response</th>
+                    <th></th>
                 </thead>
 
                 <tbody>
@@ -52,6 +53,15 @@ Officer Challenges from You
                                 <img src="{% static 'candidate/yes.png'%}" alt="confirmed" class="table-icon">
                             {% else %}
                                 <img src="{% static 'candidate/maybe.png'%}" alt="in progress" class="table-icon">
+                            {% endif %}
+                        </td>
+                        <td align="center">
+                            {% if challenge.officer_confirmed is not True %}
+                                <form action="{% url 'candidate:confirm' challenge.id %}" method="post">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="next" value="{{ request.path }}">
+                                    <input type="submit" value="Confirm" />
+                                </form>
                             {% endif %}
                         </td>
                     </tr>

--- a/hknweb/candidate/tests.py
+++ b/hknweb/candidate/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/hknweb/candidate/urls.py
+++ b/hknweb/candidate/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('offreq', views.OffRequestView.as_view(), name='offrequests'),
     path('bitbyte', views.BitByteView.as_view(), name='bitbyte'),
     path('challengeconfirm/<int:pk>/', views.officer_confirm_view, name='challengeconfirm'),
+    path('<int:id>/confirm', views.confirm_challenge, name='confirm'),
     path('detail/<int:pk>/', views.challenge_detail_view, name='detail'),
     path('reviewconfirm/<int:pk>/', views.officer_review_confirmation, name='reviewconfirm'),
     path('candreq/autocomplete/', views.OfficerAutocomplete.as_view(), name='candreq/autocomplete'),

--- a/hknweb/candidate/utils.py
+++ b/hknweb/candidate/utils.py
@@ -1,0 +1,181 @@
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.shortcuts import reverse
+from django.template.loader import render_to_string
+
+from hknweb.utils import get_rand_photo
+
+from ..events.models import Event, EventType
+
+from .constants import REQUIREMENT_TITLES_TEMPLATE, REQUIREMENT_TITLES_MANDATORY
+
+
+def send_challenge_confirm_email(request, challenge, confirmed):
+    subject = '[HKN] Your officer challenge was reviewed'
+    candidate_email = challenge.requester.email
+
+    challenge_link = request.build_absolute_uri(
+            reverse("candidate:detail", kwargs={ 'pk': challenge.id }))
+    html_content = render_to_string(
+        'candidate/challenge_confirm_email.html',
+        {
+            'subject': subject,
+            'confirmed': confirmed,
+            'officer_name': challenge.officer.get_full_name(),
+            'officer_username': challenge.officer.username,
+            'challenge_link': challenge_link,
+            'img_link': get_rand_photo(),
+        }
+    )
+    msg = EmailMultiAlternatives(subject, subject,
+                settings.NO_REPLY_EMAIL, [candidate_email])
+    msg.attach_alternative(html_content, "text/html")
+    msg.send()
+
+def send_bitbyte_confirm_email(request, bitbyte, confirmed):
+    subject = '[HKN] Your bit-byte request was reviewed'
+    participant_emails = [part.email for part in bitbyte.participants.all()]
+
+    bitbyte_link = request.build_absolute_uri(
+        reverse("candidate:bitbyte"))
+    html_content = render_to_string(
+        'candidate/bitbyte_confirm_email.html',
+        {
+            'subject': subject,
+            'confirmed': confirmed,
+            'participants': bitbyte.participants.all(),
+            'bitbyte_link': bitbyte_link,
+            'img_link': get_rand_photo(),
+        }
+    )
+    msg = EmailMultiAlternatives(subject, subject,
+                settings.NO_REPLY_EMAIL, participant_emails)
+    msg.attach_alternative(html_content, "text/html")
+    msg.send()
+
+
+""" What the event types are called on admin site.
+    Code will not work if they're called something else!! """
+map_event_vars = {
+    settings.MANDATORY_EVENT: 'Mandatory',
+    settings.FUN_EVENT: 'Fun',
+    settings.BIG_FUN_EVENT: 'Big Fun',
+    settings.SERV_EVENT: 'Serv',
+    settings.PRODEV_EVENT: 'Prodev',
+    settings.HANGOUT_EVENT: 'Hangout',
+    settings.BITBYTE_ACTIVITY: "Bit-Byte",
+}
+
+# TODO: support more flexible typing and string-to-var parsing/conversion
+def sort_rsvps_into_events(rsvps):
+    """ Takes in all confirmed rsvps and sorts them into types, currently hard coded. """
+    # Events in admin are currently in a readable format, must convert them to callable keys for Django template
+    sorted_events = dict.fromkeys(map_event_vars.keys())
+    for event_key, event_type in map_event_vars.items():
+        temp = []
+        for rsvp in rsvps.filter(event__event_type__type=event_type):
+            temp.append(rsvp.event)
+        sorted_events[event_key] = temp
+    return sorted_events
+
+
+def get_unconfirmed_events(rsvps):
+    unconfirmed_events = sort_rsvps_into_events(rsvps.filter(confirmed=False))
+
+    # We want to show all mandatory events, not just the events the candidate has RSVP'd to
+    # Get all mandatory events i.e. events with event type "Mandatory"
+    mandatory_events = Event.objects.filter(event_type__type=map_event_vars[settings.MANDATORY_EVENT])
+
+    # Initialize unconfirmed_events[settings.MANDATORY_EVENT]
+    if settings.MANDATORY_EVENT not in unconfirmed_events:
+        unconfirmed_events[settings.MANDATORY_EVENT] = []
+
+    for mandatory_event in mandatory_events:
+        # If no rsvps are found, add this mandatory event to the list of unconfirmed events
+        if rsvps.filter(event__id=mandatory_event.id).count() == 0:
+            unconfirmed_events[settings.MANDATORY_EVENT].append(mandatory_event)
+
+    return unconfirmed_events
+
+
+# TODO: increase flexibility by fetching event requirement count from database
+req_list = {
+    settings.MANDATORY_EVENT: 3,
+    settings.FUN_EVENT: 3,
+    settings.BIG_FUN_EVENT: 1,
+    settings.SERV_EVENT: 1,
+    settings.PRODEV_EVENT: 1,
+    settings.HANGOUT_EVENT: {
+        settings.HANGOUT_ATTRIBUTE_NAME: 1,
+        settings.CHALLENGE_ATTRIBUTE_NAME: 1,
+        settings.EITHER_ATTRIBUTE_NAME: 3,
+    },
+    settings.BITBYTE_ACTIVITY: 3,
+}
+
+def check_requirements(confirmed_events, unconfirmed_events, num_challenges, num_bitbytes):
+    """ Checks which requirements have been fulfilled by a candidate. """
+    req_statuses = dict.fromkeys(req_list.keys(), False)
+    req_remaining = req_list.copy()
+
+    for req_type, minimum in req_list.items():
+        if req_type == settings.BITBYTE_ACTIVITY:
+            num_confirmed = num_bitbytes
+        else:
+            num_confirmed = len(confirmed_events[req_type])
+        # officer hangouts and mandatory events are special cases
+        if req_type == settings.HANGOUT_EVENT:
+            interactivities = {
+                settings.HANGOUT_ATTRIBUTE_NAME: num_confirmed,
+                settings.CHALLENGE_ATTRIBUTE_NAME: num_challenges,
+                settings.EITHER_ATTRIBUTE_NAME: num_confirmed + num_challenges,
+            }
+            req_statuses[req_type], req_remaining[req_type] = check_interactivity_requirements(interactivities)
+        elif req_type == settings.MANDATORY_EVENT:
+            req_remaining[req_type] = len(unconfirmed_events[settings.MANDATORY_EVENT])
+            req_statuses[req_type] = req_remaining[req_type] == 0
+        elif num_confirmed >= minimum:
+            req_statuses[req_type] = True
+            req_remaining[req_type]= max(minimum - num_confirmed, 0)
+
+    return req_statuses, req_remaining
+
+INTERACTIVITY_REQUIREMENTS = req_list[settings.HANGOUT_EVENT]
+INTERACTIVITY_NAMES = {
+    settings.EITHER_ATTRIBUTE_NAME: "Interactivities",
+    settings.HANGOUT_ATTRIBUTE_NAME: "Officer Hangouts",
+    settings.CHALLENGE_ATTRIBUTE_NAME: "Officer Challenges",
+}
+
+def check_interactivity_requirements(interactivities):
+    """ Returns whether officer interactivities are satisfied. """
+    req_remaining = {}
+    for req_type, num_required in INTERACTIVITY_REQUIREMENTS.items():
+        req_remaining[req_type] = max(num_required - interactivities[req_type], 0)
+
+    req_status = not any(req_remaining.values())
+
+    return req_status, req_remaining
+
+
+def create_title(req_type: str, req_remaining: int, names: dict=map_event_vars, num_required:dict=req_list) -> str:
+    if req_type == settings.MANDATORY_EVENT:
+        return REQUIREMENT_TITLES_MANDATORY
+    elif req_type == settings.HANGOUT_EVENT:
+        return {name: create_title(name, num_required[req_type], INTERACTIVITY_NAMES, num_required[req_type]) for name in INTERACTIVITY_NAMES}
+    else:
+        return REQUIREMENT_TITLES_TEMPLATE.format(
+            name=names[req_type],
+            num_required=num_required[req_type],
+            num_remaining=req_remaining[req_type],
+        )
+
+
+def get_requirement_colors() -> dict:
+    req_colors = dict.fromkeys(map_event_vars.keys(), "grey")
+    for view_key, admin_key in map_event_vars.items():
+        event_type = EventType.objects.filter(type=admin_key).first()
+        if event_type:
+            req_colors[view_key] = event_type.color
+    
+    return req_colors

--- a/hknweb/candidate/views.py
+++ b/hknweb/candidate/views.py
@@ -13,7 +13,7 @@ from dal import autocomplete
 
 from hknweb.utils import login_and_permission, method_login_and_permission, get_rand_photo
 from .models import OffChallenge, BitByteActivity, Announcement, CandidateForm
-from ..events.models import Event, Rsvp
+from ..events.models import Event, Rsvp, EventType
 from .forms import ChallengeRequestForm, ChallengeConfirmationForm, BitByteRequestForm
 
 # views
@@ -59,6 +59,11 @@ class IndexView(generic.TemplateView):
                 .filter(start_time__range=(today, today + timezone.timedelta(days=7))) \
                 .order_by('start_time')
 
+        req_colors = dict.fromkeys(map_event_vars.keys(), "grey")
+        for view_key, admin_key in map_event_vars.items():
+            event_type = EventType.objects.filter(type=admin_key).first()
+            if event_type: req_colors[view_key] = event_type.color
+
         context = {
             'num_pending' : num_pending,
             'num_rejected' : num_rejected,
@@ -73,6 +78,7 @@ class IndexView(generic.TemplateView):
             'candidate_forms': candidate_forms,
             'req_required': req_list,
             'req_remaining': req_remaining,
+            "req_colors": req_colors,
         }
         return context
 

--- a/hknweb/candidate/views.py
+++ b/hknweb/candidate/views.py
@@ -1,6 +1,7 @@
 from django.views import generic
 from django.views.generic.edit import FormView
-from django.shortcuts import render, redirect, reverse
+from django.http import Http404
+from django.shortcuts import get_object_or_404, render, redirect, reverse
 from django.core.mail import EmailMultiAlternatives
 from django.core.exceptions import PermissionDenied
 from django.template.loader import render_to_string
@@ -220,6 +221,19 @@ def officer_confirm_view(request, pk):
         # or csec has already rejected
         return redirect('/cand/reviewconfirm/{}'.format(pk))
     return render(request, "candidate/challenge_confirm.html", context=context)
+
+@login_and_permission('candidate.change_offchallenge')
+def confirm_challenge(request, id):
+    print('hit')
+    if request.method != 'POST':
+        raise Http404()
+
+    offchallenge = get_object_or_404(OffChallenge, id=id)
+    offchallenge.officer_confirmed = True
+    offchallenge.save()
+
+    next_page = request.POST.get('next', '/')
+    return redirect(next_page)
 
 @login_and_permission('candidate.view_offchallenge')
 def officer_review_confirmation(request, pk):

--- a/hknweb/settings/common.py
+++ b/hknweb/settings/common.py
@@ -212,5 +212,8 @@ SERV_EVENT = 'serv'
 PRODEV_EVENT = 'prodev'
 HANGOUT_EVENT = 'hangout'
 BITBYTE_ACTIVITY = 'bitbyte'
+HANGOUT_ATTRIBUTE_NAME = "hangout"
+CHALLENGE_ATTRIBUTE_NAME = "challenge"
+EITHER_ATTRIBUTE_NAME = "either"
 
 # Note: both candidate and officer group should have permission to add officer challenges

--- a/hknweb/settings/common.py
+++ b/hknweb/settings/common.py
@@ -212,8 +212,10 @@ SERV_EVENT = 'serv'
 PRODEV_EVENT = 'prodev'
 HANGOUT_EVENT = 'hangout'
 BITBYTE_ACTIVITY = 'bitbyte'
-HANGOUT_ATTRIBUTE_NAME = "hangout"
-CHALLENGE_ATTRIBUTE_NAME = "challenge"
+HANGOUT_ATTRIBUTE_NAME = "officer_hangout"
+CHALLENGE_ATTRIBUTE_NAME = "officer_challenge"
 EITHER_ATTRIBUTE_NAME = "either"
+EVENTS_ATTRIBUTE_NAME = "events"
+INTERACTIVITIES_ATTRIBUTE_NAME = "interactivities"
 
 # Note: both candidate and officer group should have permission to add officer challenges

--- a/hknweb/utils.py
+++ b/hknweb/utils.py
@@ -1,4 +1,7 @@
+import csv
+
 from django.contrib.auth.decorators import login_required, permission_required
+from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.contrib.staticfiles.finders import find
 from functools import wraps
@@ -58,3 +61,19 @@ def get_semester_bounds(date):
         return datetime(date.year, 1, 1), datetime(date.year, 7, 1)
     else:
         return datetime(date.year, 7, 1), datetime(date.year + 1, 1, 1)
+
+
+# Helper. @source: http://books.agiliq.com/projects/django-admin-cookbook/en/latest/export.html
+def export_model_as_csv(model, queryset):
+    meta = model.model._meta
+    field_names = [field.name for field in meta.fields]
+
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename={}.csv'.format(meta)
+    writer = csv.writer(response)
+
+    writer.writerow(field_names)
+    for obj in queryset:
+        writer.writerow([getattr(obj, field) for field in field_names])
+
+    return response


### PR DESCRIPTION
 - Added `hknweb/candidate/utils.py` and `hknweb/candidate/constants.py` and refactored some logic into those files
 - Organized imports
 - Added color coding to candidate portal checklist event titles based off of their respective event-type color
 - Removed `hknweb/candidate/tests.py` since it wasn't being used
 - Added confirm button on officer challenge review portal
 - Refactored candidate portal index html to used for loop, enabled by refactoring view to html dataflow
 - Merged checklist and requirements section

![hkn compserv candidate portal 01](https://user-images.githubusercontent.com/46059916/95003329-0eb4e680-0593-11eb-81a1-986b2985adde.PNG)
![hkn compserv candidate portal 02](https://user-images.githubusercontent.com/46059916/95003328-0e1c5000-0593-11eb-8fa3-1765c80f767c.PNG)
