### PR TITLE
Events COMPSERV-78 COMPSERV-84 COMPSERV-94 COMPSERV-95

### DIFF
--- a/hknweb/events/forms.py
+++ b/hknweb/events/forms.py
@@ -1,10 +1,13 @@
 from django import forms
-from .models import Event
+
 from hknweb.utils import DATETIME_12_HOUR_FORMAT
+from .models import Event
+from .utils import DATETIME_WIDGET_NO_AUTOCOMPLETE
+
 
 class EventForm(forms.ModelForm):
-    start_time = forms.DateTimeField(input_formats=(DATETIME_12_HOUR_FORMAT,))
-    end_time = forms.DateTimeField(input_formats=(DATETIME_12_HOUR_FORMAT,))
+    start_time = forms.DateTimeField(input_formats=(DATETIME_12_HOUR_FORMAT,), widget=DATETIME_WIDGET_NO_AUTOCOMPLETE)
+    end_time = forms.DateTimeField(input_formats=(DATETIME_12_HOUR_FORMAT,), widget=DATETIME_WIDGET_NO_AUTOCOMPLETE)
     recurring_num_times = forms.IntegerField(min_value=0, required=False, label="Number of occurences", initial=0)
     recurring_period = forms.IntegerField(min_value=0, required=False, label="How often this event re-occurs (in weeks)", initial=0)
 

--- a/hknweb/events/templates/events/all_rsvps.html
+++ b/hknweb/events/templates/events/all_rsvps.html
@@ -4,6 +4,38 @@
 
 {% block header %}
 <link rel="stylesheet" href="{% static 'events/style.css' %}">
+<style>
+    .location-container {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .location-container .location-tooltip {
+        visibility: hidden;
+        background-color: white;
+        text-align: center;
+        border-radius: 0;
+        padding: 0;
+        white-space: normal;
+
+        /* Position the tooltip */
+        position: relative;
+        margin-top: -1.3em;
+        margin-left: 0;
+        z-index: 1;
+    }
+
+    .location-container:hover .location-tooltip {
+        visibility: visible;
+    }
+</style>
+<script>
+    if ($('#content').prop('scrollHeight') > $('#content').prop('clientHeight')) {
+        //if 'true', the content overflows the tab: we show the hidden link
+        $('#myLink').css('display', 'block');
+    }
+</script>
 {% endblock %}
 
 {% block heading %} Your RSVPs {% endblock %}
@@ -36,7 +68,7 @@
 
                 <h3>{{ rsvp_type_data.title }}</h3>
 
-                <table class="full-table" style="text-align: center;">
+                <table class="full-table" style="text-align: center; table-layout:fixed">
                     <tbody>
                         {% for event_data in rsvp_type_data.events_data %}
                             <tr>
@@ -53,7 +85,7 @@
                                 <th>Action</th>
                             </tr>
                             {% if event_data.events %}
-                                {% for event, action in event_data.events %}
+                                {% for event, action, location in event_data.events %}
                                     <tr>
                                         <td align="center">
                                             <a href="{% url 'events:detail' event.id %}" class="rounded-text-box"
@@ -65,7 +97,14 @@
                                             {% endif %}
                                         </td>
                                         <td align="center">{{ event.start_time }}</td>
-                                        <td align="center">{{ event.location }}</td>
+                                        <td align="center" style="width: 30%">
+                                            <div class="location-container">
+                                                {{ location | safe }}
+                                                <div class="location-tooltip">
+                                                    {{ location | safe }}
+                                                </div>
+                                            </div>
+                                        </td>
                                         <td align="center">
                                             <form action="{{ action }}" method="POST">
                                                 {% csrf_token %}

--- a/hknweb/events/templates/events/all_rsvps.html
+++ b/hknweb/events/templates/events/all_rsvps.html
@@ -7,8 +7,6 @@
 <style>
     .location-container {
         position: relative;
-        text-align: center;
-        background-color: white;
 
         white-space: nowrap;
         overflow: hidden;
@@ -18,17 +16,10 @@
     .location-container:hover {
         white-space: normal;
         overflow: visible;
-        background-color: white;
 
         height: 1.2em;
     }
 </style>
-<script>
-    if ($('#content').prop('scrollHeight') > $('#content').prop('clientHeight')) {
-        //if 'true', the content overflows the tab: we show the hidden link
-        $('#myLink').css('display', 'block');
-    }
-</script>
 {% endblock %}
 
 {% block heading %} Your RSVPs {% endblock %}

--- a/hknweb/events/templates/events/all_rsvps.html
+++ b/hknweb/events/templates/events/all_rsvps.html
@@ -6,28 +6,21 @@
 <link rel="stylesheet" href="{% static 'events/style.css' %}">
 <style>
     .location-container {
+        position: relative;
+        text-align: center;
+        background-color: white;
+
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
     }
 
-    .location-container .location-tooltip {
-        visibility: hidden;
-        background-color: white;
-        text-align: center;
-        border-radius: 0;
-        padding: 0;
+    .location-container:hover {
         white-space: normal;
+        overflow: visible;
+        background-color: white;
 
-        /* Position the tooltip */
-        position: relative;
-        margin-top: -1.3em;
-        margin-left: 0;
-        z-index: 1;
-    }
-
-    .location-container:hover .location-tooltip {
-        visibility: visible;
+        height: 1.2em;
     }
 </style>
 <script>
@@ -100,9 +93,6 @@
                                         <td align="center" style="width: 30%">
                                             <div class="location-container">
                                                 {{ location | safe }}
-                                                <div class="location-tooltip">
-                                                    {{ location | safe }}
-                                                </div>
                                             </div>
                                         </td>
                                         <td align="center">

--- a/hknweb/events/utils.py
+++ b/hknweb/events/utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from django import forms
+from django.core.validators import URLValidator
 
 from .constants import (
     ATTR,
@@ -101,3 +102,11 @@ def get_access_level(user):
 
 
 DATETIME_WIDGET_NO_AUTOCOMPLETE = forms.DateTimeInput(attrs={'autocomplete':'off'})
+
+def format_url(s: str, max_width: int=None) -> str:
+    url_validator = URLValidator()
+    try:
+        url_validator(s)
+        return "<a href='{link}'> {link} </a>".format(link=s)
+    except:
+        return s

--- a/hknweb/events/utils.py
+++ b/hknweb/events/utils.py
@@ -107,6 +107,6 @@ def format_url(s: str, max_width: int=None) -> str:
     url_validator = URLValidator()
     try:
         url_validator(s)
-        return "<a href='{link}'> {link} </a>".format(link=s)
+        return "<a href='{link}' style='background-color: white'> {link} </a>".format(link=s)
     except:
         return s

--- a/hknweb/events/utils.py
+++ b/hknweb/events/utils.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 
+from django import forms
+
 from .constants import (
     ATTR,
     DAY_ATTRIBUTE_NAME,
@@ -96,3 +98,6 @@ def get_access_level(user):
         if user.groups.filter(name=group_name).exists():
             access_level = min(access_level, access_value)
     return access_level
+
+
+DATETIME_WIDGET_NO_AUTOCOMPLETE = forms.DateTimeInput(attrs={'autocomplete':'off'})

--- a/hknweb/events/views.py
+++ b/hknweb/events/views.py
@@ -161,7 +161,7 @@ def show_details(request, id):
     rsvps_page = Paginator(rsvps, RSVPS_PER_PAGE).get_page(request.GET.get("rsvps_page"))
     waitlists_page = Paginator(waitlists, RSVPS_PER_PAGE).get_page(request.GET.get("waitlists_page"))
 
-    access_level = ACCESSLEVEL_TO_DESCRIPTION[get_access_level(request.user)]
+    event_access_level = ACCESSLEVEL_TO_DESCRIPTION[event.access_level]
 
     data = [
         {
@@ -186,7 +186,7 @@ def show_details(request, id):
         'event': event,
         "event_description": markdownify(event.description),
         "event_location": event_location,
-        "access_level": access_level,
+        "access_level": event_access_level,
         'rsvpd': rsvpd,
         'waitlisted': waitlisted,
         'waitlist_position': waitlist_position,

--- a/hknweb/events/views.py
+++ b/hknweb/events/views.py
@@ -13,8 +13,14 @@ from django.utils import timezone
 
 from markdownx.utils import markdownify
 
-from hknweb.utils import login_and_permission, method_login_and_permission, get_rand_photo,\
-                         get_semester_bounds, DATETIME_12_HOUR_FORMAT
+from hknweb.utils import (
+    login_and_permission,
+    method_login_and_permission,
+    get_rand_photo,
+    get_semester_bounds,
+    DATETIME_12_HOUR_FORMAT,
+    PACIFIC_TIMEZONE,
+)
 from .constants import (
     ACCESSLEVEL_TO_DESCRIPTION,
     ATTR,
@@ -266,8 +272,8 @@ class EventUpdateView(UpdateView):
         """ Override some prepopulated data with custom data; in this case, make times
             the right format. """
         initial = super().get_initial()
-        initial['start_time'] = self.object.start_time.strftime(DATETIME_12_HOUR_FORMAT)
-        initial['end_time'] = self.object.end_time.strftime(DATETIME_12_HOUR_FORMAT)
+        initial['start_time'] = self.object.start_time.astimezone(PACIFIC_TIMEZONE).strftime(DATETIME_12_HOUR_FORMAT)
+        initial['end_time'] = self.object.end_time.astimezone(PACIFIC_TIMEZONE).strftime(DATETIME_12_HOUR_FORMAT)
         return initial
 
     def form_valid(self, form):

--- a/hknweb/utils.py
+++ b/hknweb/utils.py
@@ -8,9 +8,12 @@ from functools import wraps
 from random import randint
 from datetime import datetime
 
+from pytz import timezone
+
 # constants
 
-DATETIME_12_HOUR_FORMAT = '%m/%d/%Y %I:%M %p'
+DATETIME_12_HOUR_FORMAT = '%m/%d/%Y %I:%M %p %Z'
+PACIFIC_TIMEZONE = timezone('US/Pacific')
 
 # decorators
 


### PR DESCRIPTION
(pictures can be found below the description)
- Fixed autofill in event creation start and end time form fields ([COMPSERV-78](https://hkn-mu.atlassian.net/browse/COMPSERV-78))
- Fixed timezone difference in event edit view ([COMPSERV-84](https://hkn-mu.atlassian.net/browse/COMPSERV-84))
- Fixed multiline locations in all-rsvps view ([COMPSERV-94](https://hkn-mu.atlassian.net/browse/COMPSERV-94))
- Fixed event details access level display to display event access level, not user access level ([COMPSERV-95](https://hkn-mu.atlassian.net/browse/COMPSERV-95))

It's hard to demonstrate the autofill not popping up statically, but here's a picture of what it looks like anyways (not sure if this is an entirely robust solution with respect to browsers -- tested with Chrome and Firefox and it works pretty well).
![hkn compserv events autofill no turned off for event creation start and end time](https://user-images.githubusercontent.com/46059916/98729314-94c10b80-234f-11eb-82a0-8dade73e8e5a.PNG)

The events edit times now match the event's actual times (instead of over-adjusting for timezone)
![hkn compserv events timezone difference events edit times match details](https://user-images.githubusercontent.com/46059916/98729442-c89c3100-234f-11eb-9c63-278890faa7ae.PNG)
![hkn compserv events timezone difference events details](https://user-images.githubusercontent.com/46059916/98729443-c934c780-234f-11eb-8f22-83f40a667d0b.PNG)

All-rsvps now has hidden locations that can be hovered over for full view. 
Without hovering over event location:
![hkn compserv events all rsvps vertical alignment without hover](https://user-images.githubusercontent.com/46059916/98737045-86c4b800-235a-11eb-8fc8-184236ddeadf.PNG)
With hovering over event location:
![hkn compserv events all rsvps vertical alignment with hover](https://user-images.githubusercontent.com/46059916/98737068-8cba9900-235a-11eb-9c6f-4111fcbfc83a.PNG)

Events details page now displays the event's access level, not the user's access level.
Event with access level candidate being viewed from an internal level account:
![hkn compserv events details show event access level candidate on internal level account](https://user-images.githubusercontent.com/46059916/98737268-d4d9bb80-235a-11eb-8343-8eb842c6d4b1.PNG)
