### PR TITLE
Add website-error email as Admin for Error Reporting Emails

### DIFF
--- a/hknweb/settings/common.py
+++ b/hknweb/settings/common.py
@@ -168,6 +168,9 @@ EMAIL_USE_TLS = True
 
 NO_REPLY_EMAIL = "no-reply@hkn.eecs.berkeley.edu"
 
+# Set admins and managers
+ADMINS = [('HKN', "website-errors@hkn.eecs.berkeley.edu")]
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 


### PR DESCRIPTION
As mentioned in title
No way to test except on the website server itself, which current-compserv on October 20, 2021 at 1:22 AM got