### PR TITLE
Check access level for viewing events, direct link

### DIFF
--- a/hknweb/events/views.py
+++ b/hknweb/events/views.py
@@ -146,6 +146,9 @@ class AllRsvpsView(TemplateView):
 @login_and_permission("events.view_event")
 def show_details(request, id):
     event = get_object_or_404(Event, pk=id)
+    if event.access_level < get_access_level(request.user):
+        messages.warning(request, "Insufficent permission to access event.")
+        return redirect("/events")
     rsvps = Rsvp.objects.filter(event=event)
     rsvpd = Rsvp.objects.filter(user=request.user, event=event).exists()
     waitlisted = False


### PR DESCRIPTION
If a user has a direct URL to an event but doesn't have sufficient permissions for it, then it will redirect to the "events" index page and gives a message saying insufficient permission