### PR TITLE
Filter only events user can see on Cand Portal + Invalid reCaptcha fix

### DIFF
--- a/hknweb/candidate/utils_candportal.py
+++ b/hknweb/candidate/utils_candportal.py
@@ -1,5 +1,7 @@
 from django.conf import settings
-from django.utils import get_access_level, timezone
+from django.utils import timezone
+
+from hknweb.utils import get_access_level
 
 from ..events.models import Event, Rsvp, EventType
 

--- a/hknweb/candidate/utils_candportal.py
+++ b/hknweb/candidate/utils_candportal.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils import timezone
+from django.utils import get_access_level, timezone
 
 from ..events.models import Event, Rsvp, EventType
 
@@ -414,7 +414,9 @@ class CandidatePortalData():
 
         upcoming_events = Event.objects.filter(
             start_time__range=(today, today + timezone.timedelta(days=7))
-        ).order_by("start_time")
+        ).order_by("start_time").filter(
+            access_level__gte=get_access_level(self.user)
+        )
 
         events = []
         for req_event in self.get_event_types_map(candidateSemester):

--- a/hknweb/templates/account/signup.html
+++ b/hknweb/templates/account/signup.html
@@ -5,6 +5,11 @@
 
 <div class="small-margin">
   <h2>Sign up</h2>
+  {% if messages %}
+    {% for message in messages %}
+        <h3  {% if messages.tags %} class="{{ message.tags }}" {% endif %} class="blue">{{ message }}</h3>
+    {% endfor %}
+  {% endif %}
   <form method="post" onsubmit="submit_button.disabled = true; return true;">
     {% csrf_token %}
     {{ form.as_p }}

--- a/hknweb/views/users.py
+++ b/hknweb/views/users.py
@@ -16,6 +16,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.conf import settings
+from django.forms import ValidationError
 from hknweb.models import Profile
 from hknweb.coursesemester.models import Semester
 import datetime
@@ -59,9 +60,8 @@ def account_create(request):
             if confirm_recaptcha(request):
                 form.save()
             else:
-                raise form.ValidationError(
-                    "Invalid reCAPTCHA. Please try again.", code="invalid"
-                )
+                messages.warning(request, "Invalid reCAPTCHA. Please try again.")
+                return render(request, "account/signup.html", {"form": form})
             username = form.cleaned_data.get("username")
             raw_password = form.cleaned_data.get("password1")
             user = authenticate(username=username, password=raw_password)

--- a/hknweb/views/users.py
+++ b/hknweb/views/users.py
@@ -1,9 +1,8 @@
 import urllib
 import json
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 from django.contrib.auth.models import User
 from hknweb.forms import (
-    SettingsForm,
     ProfileForm,
     SignupForm,
     ValidPasswordForm,
@@ -11,12 +10,10 @@ from hknweb.forms import (
 )
 from django.shortcuts import render, render_to_response, redirect
 from django.contrib.auth import authenticate, login, update_session_auth_hash
-from hknweb.forms import SettingsForm, ProfileForm, SignupForm
 from django.contrib.auth import authenticate
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.conf import settings
-from django.forms import ValidationError
 from hknweb.models import Profile
 from hknweb.coursesemester.models import Semester
 import datetime


### PR DESCRIPTION
Quick fix for filtering only events that users can see on the Candidate Portal. Since this is used in other places and is very minor, and a bit rushed, it will be merged and expedited 