### PR TITLE
Upgrade to focal64 for Ubuntu 20.04 - deadsnakes compadibility

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,11 +7,11 @@ Vagrant.configure("2") do |config|
   # Online documentation: https://docs.vagrantup.com.
   # Boxes: https://vagrantcloud.com/search.
 
-  # ubuntu/xenial64 box used instead of debian/stretch64 because
+  # ubuntu/focal64 box used instead of debian/stretch64 because
   # guest additions are installed by default, so the hknweb shared folder
   # may be synced with virtualbox instead of rsync, and so updates live.
   # Otherwise, both boxes use systemd and have similar packages.
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/focal64"
 
   # Automatic box update checking.
   # Disabling this causes boxes only to be checked when the user


### PR DESCRIPTION
Ubuntu 16.04 via ubuntu/xenial64 reached End of Life (EOL) on April 30, 2021
As a result, Deadsnakes ended support for it recently (https://github.com/deadsnakes/issues/issues/195)

Use newer Ubuntu 20.04 for more recent support!