### PR TITLE
Back to Ubuntu Xenial + Python 3.7.3 built from Source in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -103,8 +103,8 @@ Vagrant.configure("2") do |config|
     ln -s /usr/share/pyshared/lsb_release.py /usr/local/lib/python3.7/site-packages/lsb_release.py
 
     # Remove the Python executables (they done their purpose)
-    rm -rf Python-3.7.12
-    rm -rf Python-3.7.12.tgz
+    rm -rf Python-3.7.3
+    rm -rf Python-3.7.3.tgz
 
     # Back to main directory
     cd ~

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -101,11 +101,7 @@ Vagrant.configure("2") do |config|
     ln -fs /usr/local/bin/python3.7 /usr/bin/python
     ln -fs /usr/local/bin/python3.7 /usr/bin/python3
     ln -s /usr/share/pyshared/lsb_release.py /usr/local/lib/python3.7/site-packages/lsb_release.py
-
-    # Remove the Python executables (they done their purpose)
-    rm -rf Python-3.7.3
-    rm -rf Python-3.7.3.tgz
-
+    
     # Back to main directory
     cd ~
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,7 +64,6 @@ Vagrant.configure("2") do |config|
     ln -fs /usr/share/zoneinfo/US/Pacific /etc/localtime
     dpkg-reconfigure -f noninteractive tzdata
 
-    add-apt-repository ppa:deadsnakes/ppa
 
     apt-get update && apt-get install -y \
         curl \
@@ -74,16 +73,27 @@ Vagrant.configure("2") do |config|
         sqlite3 \
         mariadb-client \
         mariadb-server \
-        python3.7 \
-        python3.7-dev \
-        python3.7-venv \
         build-essential \
         tmux \
         vim
     
+    sudo apt update
+    sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget libbz2-dev
+    wget https://www.python.org/ftp/python/3.7.12/Python-3.7.12.tgz
+    tar -xf Python-3.7.12.tgz
+    cd Python-3.7.12
+    sudo ./configure --enable-optimizations
+    make -j 8
+    sudo make altinstall
+    
     # Force set python3.7 to the python and python3 symlinks
-    ln -fs /usr/bin/python3.7 /usr/bin/python
-    ln -fs /usr/bin/python3.7 /usr/bin/python3
+    ln -fs /usr/local/bin/python3.7 /usr/bin/python
+    ln -fs /usr/local/bin/python3.7 /usr/bin/python3
+    ln -s /usr/share/pyshared/lsb_release.py /usr/local/lib/python3.7/site-packages/lsb_release.py
+
+    # Remove the Python executables (they done their purpose)
+    rm -rf Python-3.7.12
+    rm -rf Python-3.7.12.tgz
 
     # Set up MySQL database and development user
     mysql -e "CREATE DATABASE IF NOT EXISTS hknweb;"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,11 +7,11 @@ Vagrant.configure("2") do |config|
   # Online documentation: https://docs.vagrantup.com.
   # Boxes: https://vagrantcloud.com/search.
 
-  # ubuntu/focal64 box used instead of debian/stretch64 because
+  # ubuntu/xenial64 box used instead of debian/stretch64 because
   # guest additions are installed by default, so the hknweb shared folder
   # may be synced with virtualbox instead of rsync, and so updates live.
   # Otherwise, both boxes use systemd and have similar packages.
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "ubuntu/xenial64"
 
   # Automatic box update checking.
   # Disabling this causes boxes only to be checked when the user

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,14 +77,25 @@ Vagrant.configure("2") do |config|
         tmux \
         vim
     
-    sudo apt update
-    sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget libbz2-dev
-    wget https://www.python.org/ftp/python/3.7.12/Python-3.7.12.tgz
-    tar -xf Python-3.7.12.tgz
-    cd Python-3.7.12
-    sudo ./configure --enable-optimizations
-    make -j 8
-    sudo make altinstall
+    # Install dependencies related to building Python 3.7 from source
+    apt-get update && apt-get install -y \
+        build-essential \
+        zlib1g-dev \
+        libncurses5-dev \
+        libgdbm-dev \
+        libnss3-dev \
+        libssl-dev \
+        libsqlite3-dev \
+        libreadline-dev \
+        libffi-dev \
+        wget \
+        libbz2-dev
+    cd /tmp
+    wget https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz
+    tar -xf Python-3.7.3.tgz
+    cd Python-3.7.3
+    ./configure --enable-optimizations > /dev/null
+    make -j8 altinstall > /dev/null
     
     # Force set python3.7 to the python and python3 symlinks
     ln -fs /usr/local/bin/python3.7 /usr/bin/python
@@ -94,6 +105,9 @@ Vagrant.configure("2") do |config|
     # Remove the Python executables (they done their purpose)
     rm -rf Python-3.7.12
     rm -rf Python-3.7.12.tgz
+
+    # Back to main directory
+    cd ~
 
     # Set up MySQL database and development user
     mysql -e "CREATE DATABASE IF NOT EXISTS hknweb;"


### PR DESCRIPTION
Ubuntu 16.04 via ubuntu/xenial64 reached End of Life (EOL) on April 30, 2021
As a result, Deadsnakes ended support for it recently (deadsnakes/issues#195)

The temporary fix was PR #377, but later discussions showed concern to try and remain as close to the OCF Ubuntu version as possible

So it was better to return back to Xenial, but with the desire to upgrade to Python 3.7, the alternate was to build from source, which is what this PR does (in addition to going back to Xenial)

Python 3.7.3 is used because that's the version OCF uses as of January 2022