### PR TITLE
Use debian/contrib-buster64 + modifications - Python 3.7.3 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ install:
 	#  - https://github.com/compserv/hknweb/commit/124b108
 	#  - https://github.com/hashicorp/vagrant/issues/12057
 	# This is mainly a Vagrant workaround to allow pip upgrade
-	$(PYTHON) -m pip install --upgrade pip --ignore-installed
+	$(PYTHON) -m pip install --upgrade pip setuptools --ignore-installed
 
 	make install-prod
 	$(PYTHON) -m pip install -r requirements-dev.txt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,11 +7,11 @@ Vagrant.configure("2") do |config|
   # Online documentation: https://docs.vagrantup.com.
   # Boxes: https://vagrantcloud.com/search.
 
-  # ubuntu/focal64 box used instead of debian/stretch64 because
-  # guest additions are installed by default, so the hknweb shared folder
+  # debian/contrib-buster64 is a version of Debian Buster that has
+  # guest additions installed by default, so the hknweb shared folder
   # may be synced with virtualbox instead of rsync, and so updates live.
   # Otherwise, both boxes use systemd and have similar packages.
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "debian/contrib-buster64"
 
   # Automatic box update checking.
   # Disabling this causes boxes only to be checked when the user
@@ -64,27 +64,20 @@ Vagrant.configure("2") do |config|
     ln -fs /usr/share/zoneinfo/US/Pacific /etc/localtime
     dpkg-reconfigure -f noninteractive tzdata
 
-    add-apt-repository ppa:deadsnakes/ppa
-
     apt-get update && apt-get install -y \
         curl \
         git \
-        libmysqlclient-dev \
+        default-libmysqlclient-dev \
         make \
         sqlite3 \
         mariadb-client \
         mariadb-server \
-        python3.7 \
-        python3.7-dev \
-        python3.7-venv \
+        python3-dev \
+        python3-venv \
         build-essential \
         tmux \
         vim
     
-    # Force set python3.7 to the python and python3 symlinks
-    ln -fs /usr/bin/python3.7 /usr/bin/python
-    ln -fs /usr/bin/python3.7 /usr/bin/python3
-
     # Set up MySQL database and development user
     mysql -e "CREATE DATABASE IF NOT EXISTS hknweb;"
     mysql -e "GRANT ALL PRIVILEGES ON hknweb.* TO 'hkn'@'localhost' IDENTIFIED BY 'hknweb-dev';"


### PR DESCRIPTION
Ubuntu 16.04 via ubuntu/xenial64 reached End of Life (EOL) on April 30, 2021
As a result, Deadsnakes ended support for it recently ([deadsnakes/issues#195](https://github.com/deadsnakes/issues/issues/195))

The temporary fix was PR #377, but later discussions showed concern to try and remain as close to the OCF Ubuntu version as possible

More discussion in #378, which lead to a suggestion by @jameslzhu to use Contrib Debian Buster in Vagrant (https://app.vagrantup.com/debian/boxes/contrib-buster64)
This has the Guest Additions feature needed for live updates (as mentioned in the Vagrantfile comments)

OCF's upgrades looks also to be going underway as noted here: https://www.ocf.berkeley.edu/docs/staff/backend/buster/

Buster is only two years older than what OCF uses and since it looks like OCF is gonna upgrade down the line too
