### PR TITLE
Event forms check for end time

### DIFF
--- a/hknweb/events/forms.py
+++ b/hknweb/events/forms.py
@@ -44,6 +44,13 @@ class EventForm(forms.ModelForm):
             "slug": "URL-friendly name",
             "rsvp_limit": "RSVP limit",
         }
+    
+    def clean(self):
+        cleaned_data = super().clean()
+        start_time = cleaned_data.get("start_time")
+        end_time = cleaned_data.get("end_time")
+        if end_time < start_time:
+            self.add_error("end_time", "End Time is not after Start Time")
 
 
 class EventUpdateForm(forms.ModelForm):
@@ -72,3 +79,10 @@ class EventUpdateForm(forms.ModelForm):
             "slug": "URL-friendly name",
             "rsvp_limit": "RSVP limit",
         }
+    
+    def clean(self):
+        cleaned_data = super().clean()
+        start_time = cleaned_data.get("start_time")
+        end_time = cleaned_data.get("end_time")
+        if end_time < start_time:
+            self.add_error("end_time", "End Time is not after Start Time")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29664484/155482126-982278e2-ab23-4427-a02f-a41d4e1b4ffd.png)

There was no mechanism to check if the end time is before the start time
Using the clean() function, as in the example in the [Django Documentation for form validation](https://docs.djangoproject.com/en/2.2/ref/forms/validation/), is appropriate here and the logic for this check is incorporated