### PR TITLE
BB and OffChall links to Cand Admin tab + VP Summary to Cand Summary

### DIFF
--- a/hknweb/candidate/templates/candidate/summary.html
+++ b/hknweb/candidate/templates/candidate/summary.html
@@ -17,10 +17,10 @@
 </style>
 {% endblock %}
 
-{% block title %}VP Summary{% endblock %}
+{% block title %}Candidate Summary{% endblock %}
 
 {% block heading %}
-VP Summary
+Candidate Summary
 {% endblock %}
 
 {% block content %}

--- a/hknweb/templates/base.html
+++ b/hknweb/templates/base.html
@@ -182,6 +182,10 @@
       <span class="slash">/</span>
       <a href="{% url 'candidate:create_candidates' %}">Create Candidates</a>
       <span class="slash">/</span>
+      <a href="{% url 'candidate:candrequests' %}">Confirm Officer Challenge</a>
+      <span class="slash">/</span>
+      <a href="{% url 'candidate:bitbyte' %}">Confirm Bit-Bytes</a>
+      <span class="slash">/</span>
       <a href="{% url 'candidate:summary' %}">VP Summary</a>
     </div>
     {% endif %}

--- a/hknweb/templates/base.html
+++ b/hknweb/templates/base.html
@@ -186,7 +186,7 @@
       <span class="slash">/</span>
       <a href="{% url 'candidate:bitbyte' %}">Confirm Bit-Bytes</a>
       <span class="slash">/</span>
-      <a href="{% url 'candidate:summary' %}">VP Summary</a>
+      <a href="{% url 'candidate:summary' %}">Candidate Summary</a>
     </div>
     {% endif %}
     {% if user.is_authenticated %}


### PR DESCRIPTION
BB and OffChall links to Cand Admin tab is straightforward, so it's mostly all in one place

Using "VP Summary" to "Candidate Summary" shows that it a summary of Candidates doesn't necessarily restrict to only VPs, but also to Officers wanting to look at mass who is completing requirements whether it's Bit Byte, Committee Officer, or concerned Officer / Member