### PR TITLE
"hangout" default empty list if the Hangout EventType doesn't exist

### DIFF
--- a/hknweb/candidate/utils_candportal.py
+++ b/hknweb/candidate/utils_candportal.py
@@ -490,12 +490,12 @@ class CandidatePortalData:
             "confirmed_events": {
                 **{event_key: confirmed_events[event_key]
                 for event_key in self.get_event_types_map(candidateSemester)},
-                "hangout": confirmed_events["Hangout"],
+                "hangout": confirmed_events.get("Hangout", []),
             },
             "unconfirmed_events": {
                 **{event_key: unconfirmed_events[event_key]
                 for event_key in self.get_event_types_map(candidateSemester)},
-                "hangout": unconfirmed_events["Hangout"],
+                "hangout": unconfirmed_events.get("Hangout", []),
             },
             "req_statuses": {
                 event_key: req_statuses[event_key]


### PR DESCRIPTION
https://github.com/compserv/hknweb/pull/414#discussion_r820445757

When the "Hangout" event tag is changed or deleted, the webpage will crash

It is also a minor annoyance to a developer who is working on a Candidate Portal part of the website but must remember to add the Hangout EventType (or Events) in order for the error to be suppressed (not really great extra steps towards a Candidate Portal bug fix or addition of some other unrelated to "Hangout" feature)