### PR TITLE
For course survey ratings: use a continuous/interpolated color spectrum instead of three discrete color options

### DIFF
--- a/hknweb/course_surveys/constants.py
+++ b/hknweb/course_surveys/constants.py
@@ -72,10 +72,19 @@ class CAS:
     SERVICE_VALIDATE_URL = "https://auth.berkeley.edu/cas/serviceValidate"
 
 
+# HSL tuples for interpolation for rating colors
+# e.g. 7/7 maps to green = hsl(120, 61%, 34%)
+# the red hue must be less than the yellow hue so that the color 
+# interpolated between red and yellow is orange instead of blue,
+# so just use 0 instead of 360. negative hues work fine.
 class COLORS:
-    FIRE_BRICK = "FireBrick"
-    FOREST_GREEN = "ForestGreen"
-    GOLDEN_ROD = "GoldenRod"
+    RED = (0, 68, 42)
+    YELLOW = (43, 75, 49)
+    GREEN = (120, 61, 34)
+    # the score at which the exact yellow above is used
+    # 4.2/7 non-inverted rating = 0.6 score = yellow color
+    # scores below this threshold blend with red; above with green
+    MID_SCORE = 0.6
 
 
 class UploadStages:


### PR DESCRIPTION
Before (example with discrete colors)
<img width="250" alt="image" src="https://user-images.githubusercontent.com/16441620/158074185-8c3eb05b-a50d-40f1-ab3b-f005aed84eed.png">

After (dummy course with continuous colors)
<img width="500" alt="image" src="https://user-images.githubusercontent.com/16441620/158074139-a7a4b5a9-61ef-46c3-b7f8-0dfdb2124fee.png">