### PR TITLE
MacBook Dependency Installs in Makefile - for M1 mainly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ VENV := .venv
 BIN := $(VENV)/bin
 PYTHON := $(BIN)/python
 MANAGE := HKNWEB_MODE='dev' $(PYTHON) ./manage.py
+BREW_DIR := $(shell brew --prefix)
 
 IP ?= 127.0.0.1
 PORT ?= 3000
@@ -21,6 +22,21 @@ livereload:
 venv:
 	python3 -m venv $(VENV)
 	@echo "When developing, activate the virtualenv with 'source .venv/bin/activate' so Python can access the installed dependencies."
+
+.PHONY: dependencies-macbook
+dependencies-macbook:
+	# Requirements: Homebrew (https://brew.sh/)
+	brew install mysql
+
+.PHONY: install-macbook
+install-macbook:
+	# Run dependencies-macbook first if you haven't already
+	
+	# https://stackoverflow.com/questions/67767255/error-when-install-mysqlclient-using-pip-to-macos-bigsur
+	export LDFLAGS='-L${BREW_DIR}/lib -L${BREW_DIR}/opt/openssl/lib'
+	export CPPFLAGS='-I${BREW_DIR}/include -I${BREW_DIR}/opt/openssl/include'
+
+	make install
 
 .PHONY: install-prod
 install-prod:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ make dev                      # start local web server
 $ deactivate                    # exit / deactivate the virtual environment
 ```
 
-ARM computers can follow the same instructions as M1 MacBooks, but will have to skim the dependencies installed in `make install-macbook` and the `Vagrantfile`, install them for yourself.
+ARM computers can follow the same instructions as M1 MacBooks, but will have to skim and install the dependencies listed in the `Makefile` for the `make install-macbook` command and the `Vagrantfile`
 
 Without sudo privileges, you will need to add the binary location to your `PATH` variable.
 On Linux, this is `~/.local/bin`, and on Windows, this is `AppData\Roaming\Python\bin`.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Finally, we need to install all of our dependencies:
 $ make install
 ```
 
-In summary, the setup looks like:
+In summary, for x86_64 computers, the setup looks like:
 ```sh
 $ vagrant up                    # boot up the vm
 $ vagrant ssh                   # enter into our vm
@@ -83,6 +83,21 @@ $ make dev                      # start local web server
 $ logout                        # exit the virtual machine
 $ vagrant halt                  # after developing, shut down our virtual machine
 ```
+
+In summary, for M1 MacBooks computers, the setup looks like:
+```sh
+# For M1 MacBooks, we skip Vagrant
+$ cd hknweb                     # enter our main directory
+$ make venv                     # create our virtual environment
+$ source .venv/bin/activate     # enter our virtual environment
+$ make install-macbook          # install our dependencies (for MacBooks via Homebrew)
+$ make migrate                  # apply all database changes
+$ make permissions              # initialize our database
+$ make dev                      # start local web server
+$ deactivate                    # exit / deactivate the virtual environment
+```
+
+ARM computers can follow the same instructions as M1 MacBooks, but will have to skim the dependencies installed in `make install-macbook` and the `Vagrantfile`, install them for yourself.
 
 Without sudo privileges, you will need to add the binary location to your `PATH` variable.
 On Linux, this is `~/.local/bin`, and on Windows, this is `AppData\Roaming\Python\bin`.


### PR DESCRIPTION
Reference link: https://betterprogramming.pub/managing-virtual-machines-under-vagrant-on-a-mac-m1-aebc650bc12c

As noted in the reference link, there is no current method to have Vagrant run on ARM computers
As of now, ARM computers only exists as the recently new M1 MacBooks

Since the only current source in the mass public is M1 MacBooks, this solution allows a Makefile guided install on the dependencies needed for MacBooks
The commands here are written for now as a start and there is an expectation to grow the list (especially the MacBook dependencies installed through "homebrew")

Linux users can already follow the Vagrantfile for installs

Alternates include Docker or an x86 Linux emulation as listed in the Reference Link, and so far these are easier methods to develop on for now and according to my ability

There are of course alternates to get this running on ARM, but this commit's author has no such resources to research further