### PR TITLE
Add Media symlinking line in FabFile

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -83,6 +83,7 @@ def symlink_shared(c: Connection):
     print("-- Symlinking shared files")
     with c.cd(c.release_path):
         c.run("ln -s {}/venv ./.venv".format(c.shared_path), echo=True)
+        c.run("ln -s {}/media ./media".format(c.shared_path), echo=True)
 
 
 def decrypt_secrets(c):


### PR DESCRIPTION
Related to #435 

Moved Media folder to a private folder so it won't get accessed easily via the OCF public_html

Side note: Need to determine how to present Media that is public facing
A recommendation is to use: https://github.com/edoburu/django-private-storage (but how about download when needed?)