### PR TITLE
Black Format applied to Events

### DIFF
--- a/hknweb/events/forms/event/create.py
+++ b/hknweb/events/forms/event/create.py
@@ -14,7 +14,10 @@ class EventForm(forms.ModelForm):
         input_formats=(DATETIME_12_HOUR_FORMAT,), widget=DATETIME_WIDGET_NO_AUTOCOMPLETE
     )
     repeat_num_times = forms.IntegerField(
-        min_value=0, required=False, label="Number of Repeats (after first occurrence)", initial=0
+        min_value=0,
+        required=False,
+        label="Number of Repeats (after first occurrence)",
+        initial=0,
     )
     repeat_period = forms.IntegerField(
         min_value=0,

--- a/hknweb/events/tests/views/event_transactions/test_repeat_event.py
+++ b/hknweb/events/tests/views/event_transactions/test_repeat_event.py
@@ -6,8 +6,8 @@ from django.urls import reverse
 from hknweb.events.tests.views.event_transactions.utils import setUp
 from hknweb.events.utils import generate_recurrence_times
 
-class RepeatIntervalsUtilsTests(TestCase):
 
+class RepeatIntervalsUtilsTests(TestCase):
     def test_repeat_time_intervals_base_case(self):
         start_time = datetime(2022, 3, 15, 11, 30)
         end_time = datetime(2022, 3, 15, 3, 30)
@@ -66,11 +66,26 @@ class RepeatIntervalsUtilsTests(TestCase):
         period = 1
         answer = [
             (datetime(2022, 3, 15, 11, 30), datetime(2022, 3, 15, 3, 30)),
-            (datetime(2022, 3, 15, 11, 30) + timedelta(7) , datetime(2022, 3, 15, 3, 30) + timedelta(7)),
-            (datetime(2022, 3, 15, 11, 30) + timedelta(14), datetime(2022, 3, 15, 3, 30) + timedelta(14)),
-            (datetime(2022, 3, 15, 11, 30) + timedelta(21), datetime(2022, 3, 15, 3, 30) + timedelta(21)),
-            (datetime(2022, 3, 15, 11, 30) + timedelta(28), datetime(2022, 3, 15, 3, 30) + timedelta(28)),
-            (datetime(2022, 3, 15, 11, 30) + timedelta(35), datetime(2022, 3, 15, 3, 30) + timedelta(35)),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(7),
+                datetime(2022, 3, 15, 3, 30) + timedelta(7),
+            ),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(14),
+                datetime(2022, 3, 15, 3, 30) + timedelta(14),
+            ),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(21),
+                datetime(2022, 3, 15, 3, 30) + timedelta(21),
+            ),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(28),
+                datetime(2022, 3, 15, 3, 30) + timedelta(28),
+            ),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(35),
+                datetime(2022, 3, 15, 3, 30) + timedelta(35),
+            ),
         ]
         result = generate_recurrence_times(start_time, end_time, num_repeats, period)
         self.assertListEqual(result, answer, msg="5 repeat and 1 week period")
@@ -79,11 +94,26 @@ class RepeatIntervalsUtilsTests(TestCase):
         period = 3
         answer = [
             (datetime(2022, 3, 15, 11, 30), datetime(2022, 3, 15, 3, 30)),
-            (datetime(2022, 3, 15, 11, 30) +  timedelta(21), datetime(2022, 3, 15, 3, 30) +  timedelta(21)),
-            (datetime(2022, 3, 15, 11, 30) +  timedelta(42), datetime(2022, 3, 15, 3, 30) +  timedelta(42)),
-            (datetime(2022, 3, 15, 11, 30) +  timedelta(63), datetime(2022, 3, 15, 3, 30) +  timedelta(63)),
-            (datetime(2022, 3, 15, 11, 30) +  timedelta(84), datetime(2022, 3, 15, 3, 30) +  timedelta(84)),
-            (datetime(2022, 3, 15, 11, 30) + timedelta(105), datetime(2022, 3, 15, 3, 30) + timedelta(105)),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(21),
+                datetime(2022, 3, 15, 3, 30) + timedelta(21),
+            ),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(42),
+                datetime(2022, 3, 15, 3, 30) + timedelta(42),
+            ),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(63),
+                datetime(2022, 3, 15, 3, 30) + timedelta(63),
+            ),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(84),
+                datetime(2022, 3, 15, 3, 30) + timedelta(84),
+            ),
+            (
+                datetime(2022, 3, 15, 11, 30) + timedelta(105),
+                datetime(2022, 3, 15, 3, 30) + timedelta(105),
+            ),
         ]
         result = generate_recurrence_times(start_time, end_time, num_repeats, period)
         self.assertListEqual(result, answer, msg="5 repeat and 3 week period")

--- a/hknweb/events/views/aggregate_displays/tabular.py
+++ b/hknweb/events/views/aggregate_displays/tabular.py
@@ -29,7 +29,11 @@ class AllRsvpsView(TemplateView):
         event_types = sorted(event_types, key=lambda e: not (e.type == ATTR.MANDATORY))
 
         event_type = self.request.GET.get("event_type", None)
-        event_type = event_types[0].type if ((event_type is None) and event_types) else event_type
+        event_type = (
+            event_types[0].type
+            if ((event_type is None) and event_types)
+            else event_type
+        )
         event_type = EventType.objects.filter(type=event_type).first()
 
         # Get all events


### PR DESCRIPTION
Checks did not pass formatting, and the code was in `master`
See https://github.com/compserv/hknweb/actions/runs/3034885789/jobs/4884440524

PR addresses those fixes with a simple "make format" which applies the `black` formatter
