### PR TITLE
Event timestamp fix + Test

### DIFF
--- a/hknweb/events/templatetags/event_filters.py
+++ b/hknweb/events/templatetags/event_filters.py
@@ -20,9 +20,9 @@ def military_hour_to_hour(hour):
     elif hour <= 12:
         # But more than 0
         return hour
-    elif hour >= 12:
+    else:
+        # hour > 12
         return hour - 12
-    assert False, "Should not reach here"
 
 
 # Made like this to make it compadible with Windows + Linux

--- a/hknweb/events/templatetags/event_filters.py
+++ b/hknweb/events/templatetags/event_filters.py
@@ -2,6 +2,7 @@ from django import template
 import bleach
 from django.conf import settings
 from pytz import timezone
+from datetime import datetime
 
 register = template.Library()
 
@@ -11,13 +12,26 @@ def event_name(name):
     return bleach.clean(name, tags=[], strip=True)
 
 
+def military_hour_to_hour(hour):
+    assert (0 <= hour) and (hour <= 23), "Hour outside of military time"
+    if hour == 0:
+        # Midnight
+        return 12
+    elif hour <= 12:
+        # But more than 0
+        return hour
+    elif hour >= 12:
+        return hour - 12
+    assert False, "Should not reach here"
+
+
 # Made like this to make it compadible with Windows + Linux
 #  Leading zero syntax on strftime has a difference ("#" and "-")
 def get_time_string(dt):
-    hour = dt.hour
+    hour = military_hour_to_hour(dt.hour)
     mins = dt.minute
     ampm = dt.strftime("%p")
-    return f"{hour}:{mins} {ampm}"
+    return f"{hour}:{mins:02} {ampm}"
 
 
 def get_date_string(dt):
@@ -29,14 +43,19 @@ def get_date_string(dt):
     return f"{weekday}, {month} {day}, {year} - {clock_time}"
 
 
+def get_event_timerange(start_time: datetime, end_time: datetime):
+    start_time_str = get_date_string(start_time)
+    end_time_str = ""
+    if start_time.date() == end_time.date():
+        end_time_str = get_time_string(end_time)
+    else:
+        end_time_str = get_date_string(end_time)
+    return "{} to {}".format(start_time_str, end_time_str)
+
+
 @register.filter
 def process_event_time(event):
     settings_time_zone = timezone(settings.TIME_ZONE)
-    start_time_entry = event.start_time.astimezone(settings_time_zone)
-    end_time_entry = event.end_time.astimezone(settings_time_zone)
-    start_date_time = get_date_string(start_time_entry)
-    if start_time_entry.date() == end_time_entry.date():
-        end_date_time = get_time_string(end_time_entry)
-    else:
-        end_date_time = get_date_string(end_time_entry)
-    return "{} to {}".format(start_date_time, end_date_time)
+    start_time = event.start_time.astimezone(settings_time_zone)
+    end_time = event.end_time.astimezone(settings_time_zone)
+    return get_event_timerange(start_time, end_time)

--- a/hknweb/events/tests/views/templatetags/test_event_time_output.py
+++ b/hknweb/events/tests/views/templatetags/test_event_time_output.py
@@ -1,0 +1,52 @@
+from django.test import TestCase
+
+from datetime import datetime, timedelta
+from hknweb.events.templatetags.event_filters import get_event_timerange
+
+
+class TimestampOutputTests(TestCase):
+    def test_returns_same_day_diff_time(self):
+        start_time = datetime(year=2022, month=10, day=16, hour=10, minute=30)
+        end_time = start_time + timedelta(hours=5)  # Same day, 15:30 --> 3:30 PM
+        ans = "Sun, October 16, 2022 - 10:30 AM to 3:30 PM"
+        result = get_event_timerange(start_time, end_time)
+        self.assertEqual(result, ans)
+
+    def test_returns_same_day_diff_time(self):
+        start_time = datetime(year=2022, month=10, day=16, hour=10, minute=30)
+        end_time = start_time + timedelta(days=3, hours=5)  # Oct 19, 15:30 --> 3:30 PM
+        ans = "Sun, October 16, 2022 - 10:30 AM to Wed, October 19, 2022 - 3:30 PM"
+        result = get_event_timerange(start_time, end_time)
+        self.assertEqual(result, ans)
+
+    def test_returns_same_day_diff_time_min_single_digit(self):
+        start_time = datetime(year=2022, month=10, day=16, hour=10, minute=5)
+        end_time = start_time + timedelta(hours=5)  # Same day, 15:05 --> 3:05 PM
+        ans = "Sun, October 16, 2022 - 10:05 AM to 3:05 PM"
+        result = get_event_timerange(start_time, end_time)
+        self.assertEqual(result, ans)
+
+    def test_returns_same_day_diff_time_min_single_digit(self):
+        start_time = datetime(year=2022, month=10, day=16, hour=10, minute=5)
+        end_time = start_time + timedelta(days=3, hours=5)  # Oct 19, 15:05 --> 3:05 PM
+        ans = "Sun, October 16, 2022 - 10:05 AM to Wed, October 19, 2022 - 3:05 PM"
+        result = get_event_timerange(start_time, end_time)
+        self.assertEqual(result, ans)
+
+    def test_returns_same_day_diff_time_min_single_digit_plus_few_mins(self):
+        start_time = datetime(year=2022, month=10, day=16, hour=10, minute=5)
+        end_time = start_time + timedelta(
+            days=3, hours=5, minutes=3
+        )  # Oct 19, 15:05 --> 3:05 PM
+        ans = "Sun, October 16, 2022 - 10:05 AM to Wed, October 19, 2022 - 3:08 PM"
+        result = get_event_timerange(start_time, end_time)
+        self.assertEqual(result, ans)
+
+    def test_returns_same_day_diff_time_min_to_double_digit(self):
+        start_time = datetime(year=2022, month=10, day=16, hour=10, minute=5)
+        end_time = start_time + timedelta(
+            days=3, hours=5, minutes=12
+        )  # Oct 19, 15:17 --> 3:17 PM
+        ans = "Sun, October 16, 2022 - 10:05 AM to Wed, October 19, 2022 - 3:17 PM"
+        result = get_event_timerange(start_time, end_time)
+        self.assertEqual(result, ans)


### PR DESCRIPTION
During conversion to use Conda as the development environment, one of the changes needed is the difference between Windows and Linux timestamp rendering, so a more Python way is done by grabbing info one by one and generating the desired output text

But it wasn't the correct display way, so this PR fixes that
![image](https://user-images.githubusercontent.com/29664484/196120965-9fd73320-597c-4e9e-9c04-f9f16e0c3ad7.png)

Tests also added as sanity checks to make sure any modifications confirms to the current format outputted to Events
