### PR TITLE
Add end time None check

### DIFF
--- a/hknweb/events/forms/event/create.py
+++ b/hknweb/events/forms/event/create.py
@@ -48,5 +48,7 @@ class EventForm(forms.ModelForm):
         cleaned_data = super().clean()
         start_time = cleaned_data.get("start_time")
         end_time = cleaned_data.get("end_time")
+        if end_time is None:
+            return
         if end_time < start_time:
             self.add_error("end_time", "End Time is not after Start Time")


### PR DESCRIPTION
The fact that it is required, the form validation will error the entry if the end time is forgotten, instead of it simply erroring out