### PR TITLE
Add start_time and end_time None check due to time input misformat

### DIFF
--- a/hknweb/events/forms/event/create.py
+++ b/hknweb/events/forms/event/create.py
@@ -50,6 +50,10 @@ class EventForm(forms.ModelForm):
         end_time = cleaned_data.get("end_time")
         if (start_time is None) or (end_time is None):
             error_source = "start_time" if (start_time is None) else "end_time"
-            self.add_error(error_source, "Please use the time picker to select the time, the formatter is picky")
+            self.add_error(
+                error_source,
+                "Please use the time picker to select the time, the formatter is picky",
+            )
         elif end_time < start_time:
             self.add_error("end_time", "End Time is not after Start Time")
+

--- a/hknweb/events/forms/event/create.py
+++ b/hknweb/events/forms/event/create.py
@@ -56,4 +56,3 @@ class EventForm(forms.ModelForm):
             )
         elif end_time < start_time:
             self.add_error("end_time", "End Time is not after Start Time")
-

--- a/hknweb/events/forms/event/create.py
+++ b/hknweb/events/forms/event/create.py
@@ -48,5 +48,8 @@ class EventForm(forms.ModelForm):
         cleaned_data = super().clean()
         start_time = cleaned_data.get("start_time")
         end_time = cleaned_data.get("end_time")
-        if end_time < start_time:
+        if (start_time is None) or (end_time is None):
+            error_source = "start_time" if (start_time is None) else "end_time"
+            self.add_error(error_source, "Please use the time picker to select the time, the formatter is picky")
+        elif end_time < start_time:
             self.add_error("end_time", "End Time is not after Start Time")


### PR DESCRIPTION
Formatting of the times become wrong and thus become None

The error message will recommend to use the time picker

Sample error log
start_time = '03/11/2023 2:00 PM'
end_time = '03/11/2023 4:00PM'

Notice the End Time format is not with the Start Time format standard, and thus is None