### PR TITLE
Set charset for actual unicode support

### DIFF
--- a/hknweb/settings/common.py
+++ b/hknweb/settings/common.py
@@ -104,6 +104,7 @@ DATABASES = {
         "NAME": "hknweb",
         "HOST": "mysql",
         "OPTIONS": {
+            "charset": "utf8mb4",
             "init_command": "SET sql_mode='STRICT_TRANS_TABLES'",
             "read_default_file": "~/.my.cnf",
         },


### PR DESCRIPTION
This PR fixes unicode support, allowing for (among other things) emoji to be used in event names.

Tested and ready to go.