### PR TITLE
Fix for calendar overflow issue.

### DIFF
--- a/hknweb/static/css/base.css
+++ b/hknweb/static/css/base.css
@@ -24,6 +24,7 @@ body {
 
 .content {
     padding-bottom: 1em;
+	overflow:auto;
 }
 
 /*

--- a/hknweb/templates/events/index.html
+++ b/hknweb/templates/events/index.html
@@ -185,15 +185,14 @@
         overflow: auto;
     }
 
+
     @media screen and (min-width: 1000px) {
         .content-wrapper {
 		    {% if show_sidebar %}
-				left: 3.33%;
+				left: 5%;
 			{% else %}
 				left: 12.5%;
 			{% endif %}
-			
-            position: relative;
         }
     }
 

--- a/hknweb/templates/events/index.html
+++ b/hknweb/templates/events/index.html
@@ -187,7 +187,12 @@
 
     @media screen and (min-width: 1000px) {
         .content-wrapper {
-            left: 12.5%;
+		    {% if show_sidebar %}
+				left: 3.33%;
+			{% else %}
+				left: 12.5%;
+			{% endif %}
+			
             position: relative;
         }
     }

--- a/hknweb/templates/events/index.html
+++ b/hknweb/templates/events/index.html
@@ -193,6 +193,7 @@
 			{% else %}
 				left: 12.5%;
 			{% endif %}
+			position: relative;
         }
     }
 


### PR DESCRIPTION
If screen size was above 1000px the offset of 12.5% from the left would be added to the calendar. However this would cause calendar with sidebar to overflow past the page. Changed the offset of calendar with sidebar to be 3.33%, this will mask the issue, until proper fix is found. (original calendar without the sidebar has the overflow issue too, but because of how far it is from the border it was never noticed)