### PR TITLE
Added committee-based permissions

### DIFF
--- a/hknweb/settings/common.py
+++ b/hknweb/settings/common.py
@@ -15,6 +15,8 @@ from django.conf.global_settings import DATETIME_INPUT_FORMATS
 
 from hknweb.utils import DATETIME_12_HOUR_FORMAT
 
+from enum import Enum
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -179,7 +181,27 @@ RECAPTCHA_PUBLIC_KEY = "6LeYTKAUAAAAADooVC_FG9ua47PnwP_gGWOSwauK"
 CAND_GROUP = "candidate"
 OFFICER_GROUP = "officer"
 EXEC_GROUP = "exec"
+MEMBER_GROUP = "member"
 
+# committee groups
+ACT_GROUP = "act"
+BRIDGE_GROUP = "bridge"
+COMPSEV_GROUP = "compserv"
+DECAL_GROUP = "decal"
+INDREL_GROUP = "indrel"
+PRODEV_GROUP = "prodev"
+SERV_GROUP = "serv"
+STUDREL_GROUP = "studrel"
+TUTORING_GROUP = "tutoring"
+
+# exec groups
+CSEC_GROUP = "csec"
+PRES_GROUP = "pres"
+RSEC_GROUP = "rsec"
+TRES_GROUP = "tres"
+IVP_GROUP = "ivp"
+EVP_GROUP = "evp"
+DEPREL_GROUP = "deprel"
 
 # Note: both candidate and officer group should have permission to add officer challenges
 

--- a/hknweb/studentservices/views.py
+++ b/hknweb/studentservices/views.py
@@ -13,6 +13,7 @@ from hknweb.utils import (
     allow_public_access,
     login_and_access_level,
     GROUP_TO_ACCESSLEVEL,
+    login_and_committee,
 )
 from hknweb.studentservices.models import (
     CourseGuideNode,
@@ -192,7 +193,7 @@ def course_description(request, slug):
     return render(request, "studentservices/course_description.html", context=context)
 
 
-@login_and_access_level(GROUP_TO_ACCESSLEVEL["officer"])
+@login_and_committee(settings.TUTORING_GROUP)
 def edit_description(request, slug):
     course = get_object_or_404(CourseDescription, slug=slug)
     if request.method == "GET":
@@ -211,7 +212,7 @@ def edit_description(request, slug):
     return render(request, "studentservices/course_edit.html", context=context)
 
 
-@login_and_access_level(GROUP_TO_ACCESSLEVEL["officer"])
+@login_and_committee(settings.TUTORING_GROUP)
 def delete_description(request, slug):
     course = get_object_or_404(CourseDescription, slug=slug)
 

--- a/hknweb/templates/about/people.html
+++ b/hknweb/templates/about/people.html
@@ -17,22 +17,24 @@
     }
 </style>
 <script>
-    function toggle_edit(button) {
-        button.disabled = true;
+    {% if viewer_in_bridge %}
+        function toggle_edit(button) {
+            button.disabled = true;
 
-        const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.has("edit")) {
-            urlParams.delete("edit");
-        } else {
-            urlParams.set("edit", "true");
-        }
+            const urlParams = new URLSearchParams(window.location.search);
+            if (urlParams.has("edit")) {
+                urlParams.delete("edit");
+            } else {
+                urlParams.set("edit", "true");
+            }
 
-        if (history.pushState) {
-            var newurl = window.location.origin + window.location.pathname + "?" + urlParams.toString();
-            window.history.replaceState({path: newurl}, "", newurl);
-            window.location = window.location;
+            if (history.pushState) {
+                var newurl = window.location.origin + window.location.pathname + "?" + urlParams.toString();
+                window.history.replaceState({path: newurl}, "", newurl);
+                window.location = window.location;
+            }
         }
-    }
+    {% endif %}
 </script>
 
 <script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
@@ -53,7 +55,7 @@
 {% block content %}
     <div style="text-align: center; overflow: auto;">
         <!-- Edit button -->
-        {% if is_officer %}
+        {% if viewer_in_bridge %}
             <button
                 onclick="toggle_edit(this)"
                 style="border-radius: 0.3em; border-width: 0.02em;"

--- a/hknweb/templates/committees.html
+++ b/hknweb/templates/committees.html
@@ -7,12 +7,13 @@
 
 
 {% block "portal-content" %}
-
-<a href="{% url 'tutoring:tutoring_portal' %}"> 
-    <div class="portal-content">
-        <h2>Tutoring</h2>
-    </div> 
-</a>
+{% if viewer_in_tutoring %}
+    <a href="{% url 'tutoring:tutoring_portal' %}"> 
+        <div class="portal-content">
+            <h2>Tutoring</h2>
+        </div> 
+    </a>
+{% endif %}
 
 <a href="{% url 'login' %}?next={{ request.path|urlencode }}">
     <div class="portal-content">

--- a/hknweb/templates/studentservices/course_description.html
+++ b/hknweb/templates/studentservices/course_description.html
@@ -16,7 +16,7 @@
             <!-- Title -->
             <div class="course-title-section">
                 <h2 class="course-title">{{ course.title|default:"Course Title" }}</h2>
-                {% if viewer_is_an_officer %}
+                {% if viewer_in_tutoring %}
                     <p> Last Updated: {{ course.updated_at }} </p>
                     <a href="{{ request.path }}edit"> Edit Page </a>
                 {% endif %}

--- a/hknweb/tutoring/views/courses.py
+++ b/hknweb/tutoring/views/courses.py
@@ -1,10 +1,11 @@
 from django.shortcuts import render
-from hknweb.utils import login_and_access_level, GROUP_TO_ACCESSLEVEL
+from hknweb.utils import login_and_committee
 from hknweb.studentservices.models import CourseDescription
 from hknweb.tutoring.forms import AddCourseForm
+from django.conf import settings
 
 
-@login_and_access_level(GROUP_TO_ACCESSLEVEL["officer"])
+@login_and_committee(settings.TUTORING_GROUP)
 def courses(request):
     if request.method == "POST":
         new_course = AddCourseForm(request.POST)

--- a/hknweb/tutoring/views/tutoringportal.py
+++ b/hknweb/tutoring/views/tutoringportal.py
@@ -1,7 +1,8 @@
 from django.shortcuts import render
-from hknweb.utils import login_and_access_level, GROUP_TO_ACCESSLEVEL
+from hknweb.utils import login_and_committee, GROUP_TO_ACCESSLEVEL
+from django.conf import settings
 
 
-@login_and_access_level(GROUP_TO_ACCESSLEVEL["officer"])
+@login_and_committee(settings.TUTORING_GROUP)
 def tutoringportal(request):
     return render(request, "tutoring/portal.html")

--- a/hknweb/utils.py
+++ b/hknweb/utils.py
@@ -99,6 +99,26 @@ def login_and_access_level(access_level):
     )
 
 
+# Committee Permission checks
+def committee_required(committee):
+    def test_user(user):
+        if (
+            not user.groups.filter(name=committee).exists()
+            and not user.groups.filter(name=settings.EXEC_GROUP).exists()
+        ):
+            raise PermissionDenied
+        return True
+
+    return user_passes_test(test_user)
+
+
+def login_and_committee(committee):
+    return _wrap_with_access_check(
+        f"Must be in {committee}",
+        committee_required(committee),
+    )
+
+
 def method_login_and_permission(permission_name):
     return method_decorator(login_and_permission(permission_name), name="dispatch")
 

--- a/hknweb/views/people.py
+++ b/hknweb/views/people.py
@@ -2,6 +2,8 @@ from django.shortcuts import render
 from django.db.models import QuerySet
 from django.contrib.auth.models import User
 from django.http import Http404
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
 
 from hknweb.utils import allow_public_access, get_access_level, GROUP_TO_ACCESSLEVEL
 
@@ -15,6 +17,13 @@ from hknweb.coursesemester.models import Semester
 def people(request):
     if "semester" in request.GET and not request.GET["semester"].isdigit():
         raise Http404
+
+    is_bridge = request.user.groups.filter(name=settings.BRIDGE_GROUP)
+
+    # Prevents unauthorized users from just typing the url to edit the page
+    if request.GET.get("edit") == "true":
+        if not is_bridge:
+            raise PermissionDenied
 
     semester: Semester = Semester.objects.filter(
         pk=request.GET.get("semester") or None
@@ -40,10 +49,8 @@ def people(request):
             committee__is_exec=False
         ).order_by("committee__name")
 
-    is_officer = get_access_level(request.user) <= GROUP_TO_ACCESSLEVEL["officer"]
-
     form = ProfilePictureForm(request.POST)
-    if is_officer and request.method == "POST":
+    if is_bridge and request.method == "POST":
         user = User.objects.get(pk=request.POST["user_id"])
         form.instance = user.profile
         if form.is_valid():
@@ -52,7 +59,6 @@ def people(request):
     context = {
         "execs": execs,
         "committeeships": committeeships,
-        "is_officer": is_officer,
         "form": form,
         "semester_select_form": SemesterSelectForm({"semester": semester}),
     }

--- a/hknweb/views/users.py
+++ b/hknweb/views/users.py
@@ -21,19 +21,38 @@ import datetime
 
 # context processor for base to know whether a user is in the officer group
 def add_officer_context(request):
-    return {
-        "viewer_is_an_officer": request.user.groups.filter(
-            name=settings.OFFICER_GROUP
-        ).exists()
+    usergroups = request.user.groups
+    committees = [
+        "act",
+        "bridge",
+        "compserv",
+        "decal",
+        "indrel",
+        "prodev",
+        "serv",
+        "studrel",
+        "tutoring",
+    ]
+    context = {
+        "viewer_is_an_officer": usergroups.filter(name=settings.OFFICER_GROUP).exists()
     }
+    for committee in committees:
+        context[f"viewer_in_{committee}"] = (
+            usergroups.filter(name=committee).exists()
+            or usergroups.filter(name=settings.EXEC_GROUP).exists()
+        )
+    return context
 
 
 def add_exec_context(request):
-    return {
-        "viewer_is_an_exec": request.user.groups.filter(
-            name=settings.EXEC_GROUP
-        ).exists()
+    usergroups = request.user.groups
+    execs = ["csec", "pres", "rsec", "tres", "ivp", "evp", "deprel"]
+    context = {
+        "viewer_is_an_exec": usergroups.filter(name=settings.EXEC_GROUP).exists()
     }
+    for exec in execs:
+        context[f"viewer_in_{exec}"] = usergroups.filter(name=exec).exists()
+    return context
 
 
 def get_current_cand_semester():  # pragma: no cover
@@ -77,7 +96,7 @@ def account_create(request):
                     candidate_password.lower()
                     == form.cleaned_data["candidate_password"].lower()
                 ):
-                    group = Group.objects.get(name=settings.CAND_GROUP)
+                    group = Group.objects.get(name=settings.UserGroup.CAND_GROUP)
                     group.user_set.add(user)
                     group.save()
 


### PR DESCRIPTION
Added a new decorator ( @login_and_committee(committee) ) to create committee based permissions rather than just officer/non-officer permissions. They are now implemented for both the tutoring portal as well as editing the people page.

Also added and changed the current context processor for the templates. Now in addition to checks like "viewer_is_an_officer", django will automatically replace variables such as "viewer_in_bridge" and "viewer_in_tutoring" with the appropriate true/false value. This will be helpful when an element should only be seen by certain groups.

Note that with both the decorator and the context processors, anyone in the exec group will automatically get all of the committee permissions without having to be explicitly added to the group.

To test locally, make sure to add the new groups all lowercase: "act", "bridge", "compserv", "decal", "indrel", "prodev", "serv", "studrel", "tutoring", "csec", "pres", "rsec", "tres", "ivp", "evp", "deprel". 